### PR TITLE
Expand DeviceId

### DIFF
--- a/bowler-kernel/hardware/hardware.gradle.kts
+++ b/bowler-kernel/hardware/hardware.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     api(group = "io.arrow-kt", name = "arrow-core", version = arrow_version)
     api(group = "org.kohsuke", name = "github-api", version = "1.95")
     api(group = "com.neuronrobotics", name = "SimplePacketComsJava", version = "0.8.1")
+    api(group = "com.neuronrobotics", name = "SimplePacketComsJava-HID", version = "0.1.0")
 
     implementation(group = "io.arrow-kt", name = "arrow-syntax", version = arrow_version)
     implementation(group = "org.octogonapus", name = "kt-guava-core", version = "0.0.5")

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/BowlerDeviceFactory.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/BowlerDeviceFactory.kt
@@ -24,9 +24,19 @@ import com.neuronrobotics.bowlerkernel.hardware.registry.RegisterError
 interface BowlerDeviceFactory {
 
     /**
+     * Makes a Bowler device (which runs the Bowler RPC protocol) with the specified id. Uses
+     * whatever protocol implementation is returned from the bound [BowlerDeviceFactory].
+     *
+     * @param deviceId The id of the device.
+     * @return A [BowlerDevice] on success, a [RegisterError] on failure.
+     */
+    fun makeBowlerDevice(deviceId: DeviceId): Either<RegisterError, BowlerDevice>
+
+    /**
      * Makes a Bowler device (which runs the Bowler RPC protocol) with the specified id.
      *
      * @param deviceId The id of the device.
+     * @param bowlerRPCProtocol The protocol implementation to use.
      * @return A [BowlerDevice] on success, a [RegisterError] on failure.
      */
     fun makeBowlerDevice(

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/DeviceFactory.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/DeviceFactory.kt
@@ -21,6 +21,8 @@ import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DeviceId
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultResourceIdValidator
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.ResourceIdValidator
 import com.neuronrobotics.bowlerkernel.hardware.protocol.BowlerRPCProtocol
+import com.neuronrobotics.bowlerkernel.hardware.protocol.BowlerRPCProtocolFactory
+import com.neuronrobotics.bowlerkernel.hardware.protocol.SimplePacketComsProtocolFactory
 import com.neuronrobotics.bowlerkernel.hardware.registry.HardwareRegistry
 import com.neuronrobotics.bowlerkernel.hardware.registry.RegisterError
 import org.jlleitschuh.guice.module
@@ -32,8 +34,18 @@ import javax.inject.Inject
 class DeviceFactory
 @Inject internal constructor(
     private val registry: HardwareRegistry,
-    private val resourceIdValidator: ResourceIdValidator
+    private val resourceIdValidator: ResourceIdValidator,
+    private val protocolFactory: BowlerRPCProtocolFactory
 ) : BowlerDeviceFactory {
+
+    override fun makeBowlerDevice(deviceId: DeviceId) =
+        registry.registerDevice(deviceId) {
+            BowlerDevice(
+                it,
+                protocolFactory.create(deviceId),
+                resourceIdValidator
+            )
+        }
 
     override fun makeBowlerDevice(
         deviceId: DeviceId,
@@ -48,6 +60,7 @@ class DeviceFactory
         fun deviceFactoryModule() = module {
             bind<BowlerDeviceFactory>().to<DeviceFactory>()
             bind<ResourceIdValidator>().to<DefaultResourceIdValidator>()
+            bind<BowlerRPCProtocolFactory>().to<SimplePacketComsProtocolFactory>()
         }
     }
 }

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/ConnectionMethod.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/ConnectionMethod.kt
@@ -16,12 +16,7 @@
  */
 package com.neuronrobotics.bowlerkernel.hardware.device.deviceid
 
-import com.neuronrobotics.bowlerkernel.hardware.device.Device
-
 /**
- * The id of a [Device].
+ * A method of connection from PC to Device.
  */
-data class DeviceId(
-    val deviceType: DeviceType,
-    val connectionMethod: ConnectionMethod
-)
+interface ConnectionMethod

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DefaultConnectionMethods.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DefaultConnectionMethods.kt
@@ -16,12 +16,25 @@
  */
 package com.neuronrobotics.bowlerkernel.hardware.device.deviceid
 
-import com.neuronrobotics.bowlerkernel.hardware.device.Device
+import java.net.InetAddress
 
 /**
- * The id of a [Device].
+ * The connection methods Bowler supports out-of-the-box.
  */
-data class DeviceId(
-    val deviceType: DeviceType,
-    val connectionMethod: ConnectionMethod
-)
+sealed class DefaultConnectionMethods : ConnectionMethod {
+
+    /**
+     * An internet address, typically used with UDP.
+     *
+     * @param inetAddress The IP address.
+     */
+    data class InternetAddress(val inetAddress: InetAddress) : DefaultConnectionMethods()
+
+    /**
+     * Raw HID.
+     *
+     * @param vid The vendor id.
+     * @param pid The product id.
+     */
+    data class RawHID(val vid: Int, val pid: Int) : DefaultConnectionMethods()
+}

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DefaultDeviceTypes.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DefaultDeviceTypes.kt
@@ -1,0 +1,66 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.hardware.device.deviceid
+
+import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultAttachmentPoints
+import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.ResourceId
+
+/**
+ * The device types Bowler supports out-of-the-box.
+ */
+sealed class DefaultDeviceTypes(
+    override val name: String
+) : DeviceType {
+
+    object Esp32Wroom32 : DefaultDeviceTypes(
+        "ESP32-WROOM-32"
+    ) {
+        private val digitalInPins = listOf(
+            4, 14, 16, 17, 18, 19, 21, 22, 23, 25, 26, 27, 32, 33, 34, 35, 36, 39
+        ).map { it.toByte() }
+
+        private val digitalOutPins = listOf(
+            4, 14, 16, 17, 18, 19, 21, 22, 23, 25, 26, 27, 32, 33
+        ).map { it.toByte() }
+
+        private val analogInPins = listOf(
+            4, 14, 16, 17, 18, 19, 21, 22, 23, 25, 26, 27, 32, 33
+        ).map { it.toByte() }
+
+        private val analogOutPWMPins = listOf(
+            4, 5, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 25, 26, 27, 32, 33
+        ).map { it.toByte() }
+
+        private val analogOutDACPins = listOf(25, 26).map { it.toByte() }
+
+        override fun isResourceInRange(resourceId: ResourceId): Boolean {
+            val pins = when (resourceId.attachmentPoint) {
+                is DefaultAttachmentPoints.Pin -> listOf(resourceId.attachmentPoint.pinNumber)
+
+                is DefaultAttachmentPoints.PinGroup ->
+                    resourceId.attachmentPoint.pinNumbers.toList()
+
+                else -> return false
+            }
+
+            return pins.fold(true) { acc, elem ->
+                acc && (elem in digitalInPins || elem in digitalOutPins || elem in analogInPins ||
+                    elem in analogOutPWMPins || elem in analogOutDACPins)
+            }
+        }
+    }
+}

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DeviceType.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DeviceType.kt
@@ -16,8 +16,23 @@
  */
 package com.neuronrobotics.bowlerkernel.hardware.device.deviceid
 
-data class SimpleDeviceId(
-    val id: String
-) : DeviceId {
-    override fun toString() = id
+import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.ResourceId
+
+/**
+ * The type of a device.
+ */
+interface DeviceType {
+
+    /**
+     * A simple name for the model of this device, i.e. `Arduino Zero`, `Raspberry Pi 3 B+`, etc.
+     */
+    val name: String
+
+    /**
+     * Returns whether the [resourceId] is in the valid range of resources for this device.
+     *
+     * @param resourceId The id of a resource on this device.
+     * @return Whether the resource id is in the valid range of resources for this device.
+     */
+    fun isResourceInRange(resourceId: ResourceId): Boolean
 }

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/deviceresource/resourceid/DefaultAttachmentPoints.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/deviceresource/resourceid/DefaultAttachmentPoints.kt
@@ -29,17 +29,17 @@ sealed class DefaultAttachmentPoints(
     /**
      * A single pin. The data is the pin number which is converted to an unsigned byte.
      *
-     * @param pinNumber The pin number (converted to an unsigned byte).
+     * @param pinNumber The pin number.
      */
-    data class Pin(val pinNumber: Int) : DefaultAttachmentPoints(
+    data class Pin(val pinNumber: Byte) : DefaultAttachmentPoints(
         1,
-        byteArrayOf(pinNumber.toByte())
+        byteArrayOf(pinNumber)
     )
 
     /**
      * A group of pins. The data is the number of pins followed by the pin numbers.
      *
-     * @param pinNumbers The pin numbers (converted to unsigned bytes).
+     * @param pinNumbers The pin numbers.
      */
     data class PinGroup(val pinNumbers: ByteArray) :
         DefaultAttachmentPoints(
@@ -68,10 +68,10 @@ sealed class DefaultAttachmentPoints(
     /**
      * A USB port on the device. The data is the port number converted to an unsigned byte.
      *
-     * @param portNumber The device-specific port number (converted to an unsigned byte).
+     * @param portNumber The device-specific port number.
      */
-    data class USBPort(val portNumber: Int) :
-        DefaultAttachmentPoints(3, byteArrayOf(portNumber.toByte()))
+    data class USBPort(val portNumber: Byte) :
+        DefaultAttachmentPoints(3, byteArrayOf(portNumber))
 
     /**
      * The lowest used type number.

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/deviceresource/unprovisioned/UnprovisionedDeviceResourceFactory.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/deviceresource/unprovisioned/UnprovisionedDeviceResourceFactory.kt
@@ -17,6 +17,7 @@
 package com.neuronrobotics.bowlerkernel.hardware.deviceresource.unprovisioned
 
 import arrow.core.Either
+import arrow.core.left
 import com.google.inject.assistedinject.Assisted
 import com.google.inject.assistedinject.FactoryModuleBuilder
 import com.neuronrobotics.bowlerkernel.hardware.device.BowlerDevice
@@ -60,12 +61,10 @@ class UnprovisionedDeviceResourceFactory
                 rightSide(device, resource)
             }
         } else {
-            Either.left(
-                """
-                Could not make an unprovisioned $errorMessageType with resource id
-                $resourceId because it is not in the range of resources for device $device.
-                """.trimIndent()
-            )
+            """
+            Could not make an unprovisioned $errorMessageType with resource id
+            $resourceId because it is not in the range of resources for device $device.
+            """.trimIndent().left()
         }
     }
 

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/BowlerRPCProtocolFactory.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/BowlerRPCProtocolFactory.kt
@@ -1,0 +1,33 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.hardware.protocol
+
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DeviceId
+
+/**
+ * A factory which creates [BowlerRPCProtocol].
+ */
+interface BowlerRPCProtocolFactory {
+
+    /**
+     * Creates a new [BowlerRPCProtocol].
+     *
+     * @param deviceId The device id.
+     * @return The new [BowlerRPCProtocol].
+     */
+    fun create(deviceId: DeviceId): BowlerRPCProtocol
+}

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/SimplePacketComsProtocol.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/SimplePacketComsProtocol.kt
@@ -44,7 +44,9 @@ import kotlin.math.pow
  * range are available for other packets.
  *
  * @param comms The comms implementation.
- * @param startPacketId The starting range of the packets this class creates.
+ * @param startPacketId The starting id for the packets this class creates.
+ * @param resourceIdValidator The resource id validator used to validate resource ids when adding
+ * them during discovery.
  */
 @SuppressWarnings("TooManyFunctions")
 class SimplePacketComsProtocol(

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/SimplePacketComsProtocolFactory.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/SimplePacketComsProtocolFactory.kt
@@ -1,0 +1,99 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.hardware.protocol
+
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultConnectionMethods
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DeviceId
+import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.ResourceIdValidator
+import edu.wpi.SimplePacketComs.phy.HIDSimplePacketComs
+import edu.wpi.SimplePacketComs.phy.UDPSimplePacketComs
+import javax.inject.Inject
+
+/**
+ * A [BowlerRPCProtocolFactory] which makes [SimplePacketComsProtocol]. Supports
+ * [DefaultConnectionMethods.InternetAddress] and [DefaultConnectionMethods.RawHID].
+ *
+ * @param resourceIdValidator The resource id validator to give to the [SimplePacketComsProtocol].
+ */
+class SimplePacketComsProtocolFactory
+@Inject constructor(
+    private val resourceIdValidator: ResourceIdValidator
+) : BowlerRPCProtocolFactory {
+
+    override fun create(deviceId: DeviceId): BowlerRPCProtocol {
+        val connectionMethod = deviceId.connectionMethod
+
+        return if (connectionMethod is DefaultConnectionMethods) {
+            when (connectionMethod) {
+                is DefaultConnectionMethods.InternetAddress ->
+                    SimplePacketComsProtocol(
+                        comms = UDPSimplePacketComs(connectionMethod.inetAddress),
+                        resourceIdValidator = resourceIdValidator
+                    )
+
+                is DefaultConnectionMethods.RawHID ->
+                    SimplePacketComsProtocol(
+                        comms = HIDSimplePacketComs(connectionMethod.vid, connectionMethod.pid),
+                        resourceIdValidator = resourceIdValidator
+                    )
+            }
+        } else {
+            throw UnsupportedOperationException(
+                """
+                |Cannot construct a SimplePacketComsProtocol from deviceId:
+                |$deviceId
+                """.trimMargin()
+            )
+        }
+    }
+
+    /**
+     * Creates a new [SimplePacketComsProtocol].
+     *
+     * @param deviceId The device id.
+     * @param startPacketId The start packet id.
+     * @return The new [SimplePacketComsProtocol].
+     */
+    fun create(deviceId: DeviceId, startPacketId: Int): BowlerRPCProtocol {
+        val connectionMethod = deviceId.connectionMethod
+
+        return if (connectionMethod is DefaultConnectionMethods) {
+            when (connectionMethod) {
+                is DefaultConnectionMethods.InternetAddress ->
+                    SimplePacketComsProtocol(
+                        comms = UDPSimplePacketComs(connectionMethod.inetAddress),
+                        startPacketId = startPacketId,
+                        resourceIdValidator = resourceIdValidator
+                    )
+
+                is DefaultConnectionMethods.RawHID ->
+                    SimplePacketComsProtocol(
+                        comms = HIDSimplePacketComs(connectionMethod.vid, connectionMethod.pid),
+                        startPacketId = startPacketId,
+                        resourceIdValidator = resourceIdValidator
+                    )
+            }
+        } else {
+            throw UnsupportedOperationException(
+                """
+                |Cannot construct a SimplePacketComsProtocol from deviceId:
+                |$deviceId
+                """.trimMargin()
+            )
+        }
+    }
+}

--- a/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/BowlerDeviceTest.kt
+++ b/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/BowlerDeviceTest.kt
@@ -18,7 +18,9 @@ package com.neuronrobotics.bowlerkernel.hardware.device
 
 import arrow.core.Option
 import arrow.core.getOrElse
-import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.SimpleDeviceId
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultConnectionMethods
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultDeviceTypes
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DeviceId
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.provisioned.GenericAnalogIn
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.provisioned.GenericDigitalOut
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.provisioned.GenericSerialConnection
@@ -105,7 +107,10 @@ internal class BowlerDeviceTest {
     }
 
     private val device = BowlerDevice(
-        SimpleDeviceId(""),
+        DeviceId(
+            DefaultDeviceTypes.Esp32Wroom32,
+            DefaultConnectionMethods.RawHID(0, 0)
+        ),
         bowlerRPCProtocol,
         DefaultResourceIdValidator()
     )

--- a/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/registry/BaseHardwareRegistryTest.kt
+++ b/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/registry/BaseHardwareRegistryTest.kt
@@ -18,8 +18,9 @@ package com.neuronrobotics.bowlerkernel.hardware.registry
 
 import arrow.core.Option
 import com.neuronrobotics.bowlerkernel.hardware.device.Device
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultConnectionMethods
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultDeviceTypes
 import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DeviceId
-import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.SimpleDeviceId
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultAttachmentPoints
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultResourceTypes
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.ResourceId
@@ -36,16 +37,17 @@ class BaseHardwareRegistryTest {
 
     @Test
     fun `register unregistered device`() {
-        registry.makeDeviceOrFail("A")
+        registry.makeDeviceOrFail()
     }
 
     @Test
     fun `register device twice`() {
-        registry.makeDeviceOrFail("A")
+        registry.makeDeviceOrFail()
 
         val secondRegisterError = registry.registerDevice(
-            SimpleDeviceId(
-                "A"
+            DeviceId(
+                DefaultDeviceTypes.Esp32Wroom32,
+                DefaultConnectionMethods.RawHID(0, 0)
             )
         ) {
             mock<Device> {}
@@ -56,7 +58,7 @@ class BaseHardwareRegistryTest {
 
     @Test
     fun `unregister registered device`() {
-        val device = registry.makeDeviceOrFail("A")
+        val device = registry.makeDeviceOrFail()
         val unregisterError = registry.unregisterDevice(device)
 
         assertAll(
@@ -80,7 +82,12 @@ class BaseHardwareRegistryTest {
             override fun isResourceInRange(resourceId: ResourceId) = true
         }
 
-        val device = registry.registerDevice(SimpleDeviceId("A")) {
+        val device = registry.registerDevice(
+            DeviceId(
+                DefaultDeviceTypes.Esp32Wroom32,
+                DefaultConnectionMethods.RawHID(0, 0)
+            )
+        ) {
             ThrowingMockDevice(it)
         }.fold(
             { fail<ThrowingMockDevice> { it } },
@@ -94,7 +101,7 @@ class BaseHardwareRegistryTest {
 
     @Test
     fun `unregister device twice`() {
-        val device = registry.makeDeviceOrFail("A")
+        val device = registry.makeDeviceOrFail()
 
         val unregisterError = registry.unregisterDevice(device)
         val secondUnregisterError = registry.unregisterDevice(device)
@@ -105,7 +112,7 @@ class BaseHardwareRegistryTest {
 
     @Test
     fun `unregister device with resources`() {
-        val device = registry.makeDeviceOrFail("A")
+        val device = registry.makeDeviceOrFail()
         registry.makeDeviceResourceOrFail(device, 0)
 
         val unregisterError = registry.unregisterDevice(device)
@@ -115,7 +122,7 @@ class BaseHardwareRegistryTest {
 
     @Test
     fun `register device resource`() {
-        val device = registry.makeDeviceOrFail("A")
+        val device = registry.makeDeviceOrFail()
 
         val registerError =
             registry.registerDeviceResource(
@@ -133,7 +140,7 @@ class BaseHardwareRegistryTest {
 
     @Test
     fun `register device resource twice`() {
-        val device = registry.makeDeviceOrFail("A")
+        val device = registry.makeDeviceOrFail()
         registry.makeDeviceResourceOrFail(device, 0)
 
         val secondRegisterError =
@@ -154,7 +161,12 @@ class BaseHardwareRegistryTest {
     fun `register device resource without registering device first`() {
         val registerError =
             registry.registerDeviceResource(
-                MockDevice(SimpleDeviceId("A")),
+                MockDevice(
+                    DeviceId(
+                        DefaultDeviceTypes.Esp32Wroom32,
+                        DefaultConnectionMethods.RawHID(0, 0)
+                    )
+                ),
                 ResourceId(DefaultResourceTypes.DigitalOut, DefaultAttachmentPoints.Pin(1))
             ) { _, _ ->
                 mock<UnprovisionedDeviceResource> {}
@@ -165,7 +177,7 @@ class BaseHardwareRegistryTest {
 
     @Test
     fun `unregister device resource`() {
-        val device = registry.makeDeviceOrFail("A")
+        val device = registry.makeDeviceOrFail()
         val resource = registry.makeDeviceResourceOrFail(device, 0)
 
         val unregisterError = registry.unregisterDeviceResource(resource)
@@ -175,7 +187,7 @@ class BaseHardwareRegistryTest {
 
     @Test
     fun `unregister device resource twice`() {
-        val device = registry.makeDeviceOrFail("A")
+        val device = registry.makeDeviceOrFail()
         val resource = registry.makeDeviceResourceOrFail(device, 0)
 
         val unregisterError = registry.unregisterDeviceResource(resource)
@@ -189,7 +201,12 @@ class BaseHardwareRegistryTest {
     fun `unregister device resource without registering device resource first`() {
         val unregisterError = registry.unregisterDeviceResource(
             MockUnprovisionedDeviceResource(
-                MockDevice(SimpleDeviceId("A")),
+                MockDevice(
+                    DeviceId(
+                        DefaultDeviceTypes.Esp32Wroom32,
+                        DefaultConnectionMethods.RawHID(0, 0)
+                    )
+                ),
                 ResourceId(DefaultResourceTypes.DigitalOut, DefaultAttachmentPoints.Pin(1))
             )
         )
@@ -199,7 +216,7 @@ class BaseHardwareRegistryTest {
 
     @Test
     fun `register two device resources on same attachment points with different types`() {
-        val device = registry.makeDeviceOrFail("A")
+        val device = registry.makeDeviceOrFail()
 
         val digitalOut = registry.registerDeviceResource(
             device,

--- a/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/registry/HardwareRegistryTrackerTest.kt
+++ b/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/registry/HardwareRegistryTrackerTest.kt
@@ -20,8 +20,9 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.hasSize
 import com.neuronrobotics.bowlerkernel.hardware.device.Device
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultConnectionMethods
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultDeviceTypes
 import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DeviceId
-import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.SimpleDeviceId
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultAttachmentPoints
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultResourceTypes
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.ResourceId
@@ -39,7 +40,7 @@ class HardwareRegistryTrackerTest {
 
     @Test
     fun `successfully register a device`() {
-        registry.makeDeviceOrFail("A")
+        registry.makeDeviceOrFail()
 
         assertAll(
             {
@@ -48,8 +49,11 @@ class HardwareRegistryTrackerTest {
             {
                 assertEquals(
                     registry.sessionRegisteredDevices.map { it.deviceId },
-                    listOf<DeviceId>(
-                        SimpleDeviceId("A")
+                    listOf(
+                        DeviceId(
+                            DefaultDeviceTypes.Esp32Wroom32,
+                            DefaultConnectionMethods.RawHID(0, 0)
+                        )
                     )
                 )
             }
@@ -58,9 +62,12 @@ class HardwareRegistryTrackerTest {
 
     @Test
     fun `fail to register a device`() {
-        baseRegistry.makeDeviceOrFail("A")
+        baseRegistry.makeDeviceOrFail()
         registry.registerDevice(
-            SimpleDeviceId("A")
+            DeviceId(
+                DefaultDeviceTypes.Esp32Wroom32,
+                DefaultConnectionMethods.RawHID(0, 0)
+            )
         ) { mock<MockDevice> {} }
 
         assertAll(
@@ -75,7 +82,7 @@ class HardwareRegistryTrackerTest {
 
     @Test
     fun `successfully unregister a device`() {
-        registry.unregisterDevice(registry.makeDeviceOrFail("A"))
+        registry.unregisterDevice(registry.makeDeviceOrFail())
 
         assertAll(
             {
@@ -91,7 +98,10 @@ class HardwareRegistryTrackerTest {
     fun `fail to unregister a device`() {
         registry.unregisterDevice(
             MockDevice(
-                SimpleDeviceId("A")
+                DeviceId(
+                    DefaultDeviceTypes.Esp32Wroom32,
+                    DefaultConnectionMethods.RawHID(0, 0)
+                )
             )
         )
 
@@ -107,7 +117,7 @@ class HardwareRegistryTrackerTest {
 
     @Test
     fun `successfully register a device resource`() {
-        val device = registry.makeDeviceOrFail("A")
+        val device = registry.makeDeviceOrFail()
         registry.makeDeviceResourceOrFail(device, 0)
 
         assertAll(
@@ -119,9 +129,10 @@ class HardwareRegistryTrackerTest {
                     registry.sessionRegisteredDeviceResources.entries().map {
                         it.key.deviceId to it.value.resourceId
                     }.toMap(),
-                    mapOf<DeviceId, ResourceId>(
-                        SimpleDeviceId(
-                            "A"
+                    mapOf(
+                        DeviceId(
+                            DefaultDeviceTypes.Esp32Wroom32,
+                            DefaultConnectionMethods.RawHID(0, 0)
                         ) to ResourceId(
                             DefaultResourceTypes.DigitalOut, DefaultAttachmentPoints.Pin(0)
                         )
@@ -134,7 +145,12 @@ class HardwareRegistryTrackerTest {
     @Test
     fun `fail to register a device resource`() {
         registry.registerDeviceResource(
-            MockDevice(SimpleDeviceId("A")),
+            MockDevice(
+                DeviceId(
+                    DefaultDeviceTypes.Esp32Wroom32,
+                    DefaultConnectionMethods.RawHID(0, 0)
+                )
+            ),
             ResourceId(DefaultResourceTypes.DigitalOut, DefaultAttachmentPoints.Pin(1))
         ) { _, _ -> mock<UnprovisionedDeviceResource> {} }
 
@@ -150,7 +166,7 @@ class HardwareRegistryTrackerTest {
 
     @Test
     fun `successfully unregister a device resource`() {
-        val device = registry.makeDeviceOrFail("A")
+        val device = registry.makeDeviceOrFail()
         registry.unregisterDeviceResource(registry.makeDeviceResourceOrFail(device, 0))
 
         assertAll(
@@ -168,7 +184,7 @@ class HardwareRegistryTrackerTest {
 
     @Test
     fun `fail to unregister a device resource`() {
-        val device = registry.makeDeviceOrFail("A")
+        val device = registry.makeDeviceOrFail()
         registry.unregisterDeviceResource(
             MockUnprovisionedDeviceResource(
                 device,
@@ -188,7 +204,7 @@ class HardwareRegistryTrackerTest {
 
     @Test
     fun `unregister all devices and resources`() {
-        val device = registry.makeDeviceOrFail("A")
+        val device = registry.makeDeviceOrFail()
         registry.makeDeviceResourceOrFail(device, 0)
 
         val unregisterErrors = registry.unregisterAllHardware()
@@ -202,7 +218,7 @@ class HardwareRegistryTrackerTest {
 
     @Test
     fun `unregister all devices and resources with errors`() {
-        val device = registry.makeDeviceOrFail("A")
+        val device = registry.makeDeviceOrFail()
         val resource = registry.makeDeviceResourceOrFail(device, 0)
 
         baseRegistry.unregisterDeviceResource(resource)

--- a/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/registry/RegistryTestUtil.kt
+++ b/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/registry/RegistryTestUtil.kt
@@ -18,8 +18,9 @@ package com.neuronrobotics.bowlerkernel.hardware.registry
 
 import arrow.core.Option
 import com.neuronrobotics.bowlerkernel.hardware.device.Device
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultConnectionMethods
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultDeviceTypes
 import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DeviceId
-import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.SimpleDeviceId
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.provisioned.ProvisionedDeviceResource
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultAttachmentPoints
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultResourceTypes
@@ -59,8 +60,13 @@ internal class MockProvisionedDeviceResource(
     override val resourceId: ResourceId
 ) : ProvisionedDeviceResource
 
-internal fun HardwareRegistry.makeDeviceOrFail(id: String): MockDevice =
-    registerDevice(SimpleDeviceId(id)) {
+internal fun HardwareRegistry.makeDeviceOrFail(): MockDevice =
+    registerDevice(
+        DeviceId(
+            DefaultDeviceTypes.Esp32Wroom32,
+            DefaultConnectionMethods.RawHID(0, 0)
+        )
+    ) {
         MockDevice(it)
     }.fold(
         { fail<MockDevice> { it } },
@@ -69,7 +75,7 @@ internal fun HardwareRegistry.makeDeviceOrFail(id: String): MockDevice =
 
 internal fun HardwareRegistry.makeDeviceResourceOrFail(
     device: Device,
-    attachmentPoint: Int
+    attachmentPoint: Byte
 ): MockUnprovisionedDeviceResource =
     registerDeviceResource(
         device,

--- a/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/unprovisioned/UnprovisionedDeviceResourceFactoryTest.kt
+++ b/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/unprovisioned/UnprovisionedDeviceResourceFactoryTest.kt
@@ -21,7 +21,9 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.hasSize
 import com.neuronrobotics.bowlerkernel.hardware.device.BowlerDevice
-import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.SimpleDeviceId
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultConnectionMethods
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultDeviceTypes
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DeviceId
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultAttachmentPoints
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultResourceTypes
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.ResourceId
@@ -40,7 +42,6 @@ class UnprovisionedDeviceResourceFactoryTest {
 
     @Test
     fun `test resource id out of range`() {
-        val deviceName = "A"
         val resourceId = DefaultAttachmentPoints.Pin(0)
 
         val device = mock<BowlerDevice> {
@@ -54,7 +55,12 @@ class UnprovisionedDeviceResourceFactoryTest {
             } doReturn false
         }
 
-        registry.registerDevice(SimpleDeviceId(deviceName)) { device }
+        registry.registerDevice(
+            DeviceId(
+                DefaultDeviceTypes.Esp32Wroom32,
+                DefaultConnectionMethods.RawHID(0, 0)
+            )
+        ) { device }
         val error = UnprovisionedDeviceResourceFactory(registry, device)
             .makeUnprovisionedDigitalOut(resourceId)
 
@@ -172,8 +178,6 @@ class UnprovisionedDeviceResourceFactoryTest {
         resourceId: ResourceId,
         makeResource: UnprovisionedDeviceResourceFactory.() -> Either<RegisterError, UnprovisionedDeviceResource>
     ) {
-        val deviceName = "A"
-
         val device = mock<BowlerDevice> {
             on {
                 isResourceInRange(resourceId)
@@ -181,10 +185,18 @@ class UnprovisionedDeviceResourceFactoryTest {
 
             on {
                 deviceId
-            } doReturn SimpleDeviceId(deviceName)
+            } doReturn DeviceId(
+                DefaultDeviceTypes.Esp32Wroom32,
+                DefaultConnectionMethods.RawHID(0, 0)
+            )
         }
 
-        registry.registerDevice(SimpleDeviceId(deviceName)) { device }
+        registry.registerDevice(
+            DeviceId(
+                DefaultDeviceTypes.Esp32Wroom32,
+                DefaultConnectionMethods.RawHID(0, 0)
+            )
+        ) { device }
 
         val resource = UnprovisionedDeviceResourceFactory(registry, device).makeResource()
 
@@ -197,8 +209,6 @@ class UnprovisionedDeviceResourceFactoryTest {
         resourceId: ResourceId,
         makeResource: UnprovisionedDeviceResourceFactory.() -> Either<RegisterError, UnprovisionedDeviceResource>
     ) {
-        val deviceName = "A"
-
         val device = mock<BowlerDevice> {
             on {
                 isResourceInRange(resourceId)
@@ -206,10 +216,18 @@ class UnprovisionedDeviceResourceFactoryTest {
 
             on {
                 deviceId
-            } doReturn SimpleDeviceId(deviceName)
+            } doReturn DeviceId(
+                DefaultDeviceTypes.Esp32Wroom32,
+                DefaultConnectionMethods.RawHID(0, 0)
+            )
         }
 
-        registry.registerDevice(SimpleDeviceId(deviceName)) { device }
+        registry.registerDevice(
+            DeviceId(
+                DefaultDeviceTypes.Esp32Wroom32,
+                DefaultConnectionMethods.RawHID(0, 0)
+            )
+        ) { device }
 
         val resource = UnprovisionedDeviceResourceFactory(registry, device).makeResource()
 

--- a/bowler-kernel/scripting/src/test/kotlin/com/neuronrobotics/bowlerkernel/scripting/HardwareScriptIntegrationTest.kt
+++ b/bowler-kernel/scripting/src/test/kotlin/com/neuronrobotics/bowlerkernel/scripting/HardwareScriptIntegrationTest.kt
@@ -20,7 +20,9 @@ import arrow.core.Either
 import com.google.common.collect.ImmutableList
 import com.neuronrobotics.bowlerkernel.hardware.Script
 import com.neuronrobotics.bowlerkernel.hardware.device.BowlerDeviceFactory
-import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.SimpleDeviceId
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultConnectionMethods
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultDeviceTypes
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DeviceId
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultAttachmentPoints
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.unprovisioned.UnprovisionedDigitalOutFactory
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.unprovisioned.UnprovisionedServoFactory
@@ -62,7 +64,10 @@ internal class HardwareScriptIntegrationTest {
 
         override fun runScript(args: ImmutableList<Any?>): Either<String, Any?> {
             val device = bowlerDeviceFactory.makeBowlerDevice(
-                SimpleDeviceId("/dev/ttyACM0"),
+                DeviceId(
+                    DefaultDeviceTypes.Esp32Wroom32,
+                    DefaultConnectionMethods.RawHID(0, 0)
+                ),
                 MockBowlerRPCProtocol()
             ).fold({ fail { "" } }, { it })
 

--- a/bowler-kernel/scripting/src/test/kotlin/com/neuronrobotics/bowlerkernel/scripting/ScriptIntegrationTest.kt
+++ b/bowler-kernel/scripting/src/test/kotlin/com/neuronrobotics/bowlerkernel/scripting/ScriptIntegrationTest.kt
@@ -21,7 +21,9 @@ import arrow.core.getOrHandle
 import com.google.common.collect.ImmutableList
 import com.neuronrobotics.bowlerkernel.hardware.Script
 import com.neuronrobotics.bowlerkernel.hardware.device.BowlerDeviceFactory
-import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.SimpleDeviceId
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultConnectionMethods
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultDeviceTypes
+import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DeviceId
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultAttachmentPoints
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.unprovisioned.UnprovisionedDigitalOutFactory
 import com.neuronrobotics.bowlerkernel.scripting.factory.DefaultTextScriptFactory
@@ -44,7 +46,10 @@ class ScriptIntegrationTest {
     ) {
         init {
             val device = bowlerDeviceFactory.makeBowlerDevice(
-                SimpleDeviceId("bowler-device-id"),
+                DeviceId(
+                    DefaultDeviceTypes.Esp32Wroom32,
+                    DefaultConnectionMethods.RawHID(0, 0)
+                ),
                 MockBowlerRPCProtocol()
             ).getOrHandle {
                 fail {
@@ -89,7 +94,9 @@ class ScriptIntegrationTest {
         val scriptText =
             """
             import com.neuronrobotics.bowlerkernel.hardware.device.BowlerDeviceFactory
-            import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.SimpleDeviceId
+            import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultConnectionMethods
+            import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultDeviceTypes
+            import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DeviceId
             import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultAttachmentPoints
             import com.neuronrobotics.bowlerkernel.hardware.deviceresource.unprovisioned.UnprovisionedDigitalOutFactory
             import com.neuronrobotics.bowlerkernel.scripting.MockBowlerRPCProtocol
@@ -105,17 +112,20 @@ class ScriptIntegrationTest {
                      UnprovisionedDigitalOutFactory.Factory ledFactoryFactory
                 ) {
                     bowlerDeviceFactory.makeBowlerDevice(
-                            new SimpleDeviceId("device A"),
+                            new DeviceId(
+                                    new DefaultDeviceTypes.Esp32Wroom32(),
+                                    new DefaultConnectionMethods.RawHID(0, 0)
+                            ),
                             new MockBowlerRPCProtocol()
                     ).map {
                         it.connect()
 
-                        it.add(ledFactoryFactory.create(it).makeUnprovisionedDigitalOut(
+                        ledFactoryFactory.create(it).makeUnprovisionedDigitalOut(
                                 new DefaultAttachmentPoints.Pin(1 as byte)
-                        ).fold({ }, {
+                        ).map { led1 ->
                             worked = true
-                            it
-                        }))
+                            it.add(led1)
+                        }
 
                         it.disconnect()
                     }
@@ -195,7 +205,9 @@ class ScriptIntegrationTest {
             import com.google.common.collect.ImmutableList
             import com.neuronrobotics.bowlerkernel.hardware.Script
             import com.neuronrobotics.bowlerkernel.hardware.device.BowlerDeviceFactory
-            import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.SimpleDeviceId
+            import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultConnectionMethods
+            import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DefaultDeviceTypes
+            import com.neuronrobotics.bowlerkernel.hardware.device.deviceid.DeviceId
             import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultAttachmentPoints
             import com.neuronrobotics.bowlerkernel.hardware.deviceresource.unprovisioned.UnprovisionedDigitalOutFactory
             import com.neuronrobotics.bowlerkernel.scripting.MockBowlerRPCProtocol
@@ -211,7 +223,10 @@ class ScriptIntegrationTest {
 
                 override fun runScript(args: ImmutableList<Any?>): Either<String, Any?> {
                     bowlerDeviceFactory.makeBowlerDevice(
-                        SimpleDeviceId("device A"),
+                        DeviceId(
+                            DefaultDeviceTypes.Esp32Wroom32,
+                            DefaultConnectionMethods.RawHID(0, 0)
+                        ),
                         MockBowlerRPCProtocol()
                     ).map {
                         it.connect()


### PR DESCRIPTION
### Description of the Change

This PR expands `DeviceId` into something analogous to `ResourceId`. `DeviceId` now has a `DeviceType` (where we can validate pin numbers, etc.) and a `ConnectionMethod` (where we can get info for how to construct the RPC).

### Benefits

`DeviceId` isn't useless any more :upside_down_face:

### Possible Drawbacks


### Verification Process


### Applicable Issues

Closes #1.
