### PR TITLE
Add Vitamin and a few other interfaces

### DIFF
--- a/bowler-kernel.gradle.kts
+++ b/bowler-kernel.gradle.kts
@@ -46,7 +46,7 @@ object Strings {
 }
 
 val bowlerKernelProject = project(":bowler-kernel")
-val bowlerKernelConfigProject = project(":bowler-kernel:config")
+val bowlerKernelSettingsProject = project(":bowler-kernel:config")
 val bowlerKernelGitFSProject = project(":bowler-kernel:gitfs")
 val bowlerKernelHardwareProject = project(":bowler-kernel:hardware")
 val bowlerKernelKinematicsProject = project(":bowler-kernel:kinematics")
@@ -57,7 +57,7 @@ val bowlerKernelVitaminsProject = project(":bowler-kernel:vitamins")
 
 val kotlinProjects = setOf(
     bowlerKernelProject,
-    bowlerKernelConfigProject,
+    bowlerKernelSettingsProject,
     bowlerKernelGitFSProject,
     bowlerKernelHardwareProject,
     bowlerKernelKinematicsProject,

--- a/bowler-kernel.gradle.kts
+++ b/bowler-kernel.gradle.kts
@@ -36,21 +36,25 @@ allprojects {
 }
 
 val bowlerKernelProject = project(":bowler-kernel")
+val bowlerKernelConfigProject = project(":bowler-kernel:config")
 val bowlerKernelGitFSProject = project(":bowler-kernel:gitfs")
 val bowlerKernelHardwareProject = project(":bowler-kernel:hardware")
 val bowlerKernelKinematicsProject = project(":bowler-kernel:kinematics")
 val bowlerKernelLoggingProject = project(":bowler-kernel:logging")
 val bowlerKernelScriptingProject = project(":bowler-kernel:scripting")
-val bowlerKernelSettingsProject = project(":bowler-kernel:config")
+val bowlerKernelUtilProject = project(":bowler-kernel:util")
+val bowlerKernelVitaminsProject = project(":bowler-kernel:vitamins")
 
 val kotlinProjects = setOf(
     bowlerKernelProject,
+    bowlerKernelConfigProject,
     bowlerKernelGitFSProject,
     bowlerKernelHardwareProject,
     bowlerKernelKinematicsProject,
     bowlerKernelLoggingProject,
     bowlerKernelScriptingProject,
-    bowlerKernelSettingsProject
+    bowlerKernelUtilProject,
+    bowlerKernelVitaminsProject
 )
 
 val javaProjects = setOf<Project>() + kotlinProjects

--- a/bowler-kernel/kinematics/kinematics.gradle.kts
+++ b/bowler-kernel/kinematics/kinematics.gradle.kts
@@ -7,6 +7,7 @@ repositories {
 dependencies {
     api(group = "org.ejml", name = "ejml-all", version = "0.37.1")
     api(project(":bowler-kernel:scripting"))
+    api(project(":bowler-kernel:util"))
 
     implementation(group = "org.octogonapus", name = "kt-guava-core", version = "0.0.5")
     implementation(group = "com.google.inject", name = "guice", version = "4.1.0")

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/DefaultLink.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/DefaultLink.kt
@@ -16,8 +16,8 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics.limb.link
 
-import com.neuronrobotics.bowlerkernel.kinematics.Limits
 import com.neuronrobotics.bowlerkernel.kinematics.motion.InertialStateEstimator
+import com.neuronrobotics.bowlerkernel.util.Limits
 
 data class DefaultLink(
     override val type: LinkType,

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/DefaultLinkFactory.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/DefaultLinkFactory.kt
@@ -16,8 +16,8 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics.limb.link
 
-import com.neuronrobotics.bowlerkernel.kinematics.Limits
 import com.neuronrobotics.bowlerkernel.kinematics.motion.InertialStateEstimator
+import com.neuronrobotics.bowlerkernel.util.Limits
 
 class DefaultLinkFactory : LinkFactory {
 

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/LinkFactory.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/LinkFactory.kt
@@ -16,8 +16,8 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics.limb.link
 
-import com.neuronrobotics.bowlerkernel.kinematics.Limits
 import com.neuronrobotics.bowlerkernel.kinematics.motion.InertialStateEstimator
+import com.neuronrobotics.bowlerkernel.util.Limits
 
 interface LinkFactory {
 

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/control/kinematics/KinematicsTestUtil.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/control/kinematics/KinematicsTestUtil.kt
@@ -17,7 +17,6 @@
 package com.neuronrobotics.bowlerkernel.control.kinematics
 
 import com.neuronrobotics.bowlerkernel.gitfs.GitFile
-import com.neuronrobotics.bowlerkernel.kinematics.Limits
 import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.SimpleKinematicBaseId
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseData
 import com.neuronrobotics.bowlerkernel.kinematics.limb.limbid.SimpleLimbId
@@ -26,6 +25,7 @@ import com.neuronrobotics.bowlerkernel.kinematics.limb.model.DhParamData
 import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbData
 import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LinkData
 import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
+import com.neuronrobotics.bowlerkernel.util.Limits
 import org.octogonapus.ktguava.collections.immutableListOf
 
 @SuppressWarnings("LongParameterList")

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/control/kinematics/limb/DefaultLimbIntegrationTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/control/kinematics/limb/DefaultLimbIntegrationTest.kt
@@ -19,7 +19,6 @@ package com.neuronrobotics.bowlerkernel.control.kinematics.limb
 import com.google.common.collect.ImmutableList
 import com.neuronrobotics.bowlerkernel.control.createMotionConstraints
 import com.neuronrobotics.bowlerkernel.control.kinematics.MockJointAngleController
-import com.neuronrobotics.bowlerkernel.kinematics.Limits
 import com.neuronrobotics.bowlerkernel.kinematics.limb.DefaultLimb
 import com.neuronrobotics.bowlerkernel.kinematics.limb.limbid.SimpleLimbId
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DefaultLink
@@ -33,6 +32,7 @@ import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.DefaultLimbMotionP
 import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.LimbMotionPlan
 import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.LimbMotionPlanGenerator
 import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.LimbMotionPlanStep
+import com.neuronrobotics.bowlerkernel.util.Limits
 import com.nhaarman.mockitokotlin2.mock
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking

--- a/bowler-kernel/util/src/main/kotlin/com/neuronrobotics/bowlerkernel/util/Limits.kt
+++ b/bowler-kernel/util/src/main/kotlin/com/neuronrobotics/bowlerkernel/util/Limits.kt
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.neuronrobotics.bowlerkernel.kinematics
+package com.neuronrobotics.bowlerkernel.util
 
 /**
  * A generic limits class.

--- a/bowler-kernel/util/util.gradle.kts
+++ b/bowler-kernel/util/util.gradle.kts
@@ -1,0 +1,1 @@
+description = "A generic utilities module."

--- a/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/BallBearing.kt
+++ b/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/BallBearing.kt
@@ -1,0 +1,36 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.vitamins
+
+/**
+ * A generic ball bearing. [Vitamin.width] should be the width (between the two flat faces of the
+ * bearing). For rotational bearings, [Vitamin.height] and [Vitamin.length] should be equal to each
+ * other and to the outer diameter. For linear bearings, [Vitamin.height] should be equal to the
+ * outer diameter and [Vitamin.length] should be equal to either the outer diameter or the
+ * outer housing dimension.
+ *
+ * Good things to put in [Vitamin.specs]:
+ *  - Construction type
+ *  - Lubrication
+ */
+interface BallBearing : Vitamin {
+
+    /**
+     * The bore diameter (where the shaft goes).
+     */
+    val bore: Double
+}

--- a/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/Battery.kt
+++ b/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/Battery.kt
@@ -14,16 +14,35 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.neuronrobotics.bowlerkernel.kinematics.limb.model
+package com.neuronrobotics.bowlerkernel.vitamins
 
-import com.neuronrobotics.bowlerkernel.gitfs.GitFile
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.LinkType
-import com.neuronrobotics.bowlerkernel.util.Limits
+/**
+ * A generic battery.
+ *
+ * Good things to put in [Vitamin.specs]:
+ *  - Number of cells
+ *  - Connector type
+ *  - Chemistry
+ */
+interface Battery : Vitamin {
 
-data class LinkData(
-    val type: LinkType,
-    val dhParamData: DhParamData,
-    val jointLimits: Limits,
-    val jointAngleController: GitFile,
-    val inertialStateEstimator: GitFile
-)
+    /**
+     * The nominal voltage.
+     */
+    val voltage: Double
+
+    /**
+     * The maximum continuous current draw.
+     */
+    val current: Double
+
+    /**
+     * The maximum continuous discharge rate.
+     */
+    val dischargeRate: Double
+
+    /**
+     * The capacity.
+     */
+    val capacity: Double
+}

--- a/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/CenterOfMass.kt
+++ b/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/CenterOfMass.kt
@@ -14,16 +14,10 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.neuronrobotics.bowlerkernel.kinematics.limb.model
+package com.neuronrobotics.bowlerkernel.vitamins
 
-import com.neuronrobotics.bowlerkernel.gitfs.GitFile
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.LinkType
-import com.neuronrobotics.bowlerkernel.util.Limits
-
-data class LinkData(
-    val type: LinkType,
-    val dhParamData: DhParamData,
-    val jointLimits: Limits,
-    val jointAngleController: GitFile,
-    val inertialStateEstimator: GitFile
+data class CenterOfMass(
+    val x: Double,
+    val y: Double,
+    val z: Double
 )

--- a/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/DCMotor.kt
+++ b/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/DCMotor.kt
@@ -14,35 +14,52 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.neuronrobotics.bowlerkernel.kinematics.limb.link
+package com.neuronrobotics.bowlerkernel.vitamins
 
-import com.neuronrobotics.bowlerkernel.kinematics.limb.Limb
-import com.neuronrobotics.bowlerkernel.kinematics.motion.InertialStateEstimator
 import com.neuronrobotics.bowlerkernel.util.Limits
 
 /**
- * A link which can form the chain of a [Limb].
+ * A generic DC motor.
+ *
+ * Good things to put in [Vitamin.specs]:
+ *  - Peak power RPM
+ *  - Peak efficiency RPM
+ *  - Mounting holes (Vitamin for the screws and a bolt circle diameter)
  */
-interface Link {
+interface DCMotor : Vitamin {
 
     /**
-     * The type of this link.
+     * The operating voltage limits.
      */
-    val type: LinkType
+    val voltage: Limits
 
     /**
-     * The DH description of this link.
+     * The output shaft diameter.
      */
-    val dhParam: DhParam
+    val outputShaftDiameter: Double
 
     /**
-     * The movement limits of this link. This can represent angle for a rotary link or length for
-     * a prismatic link.
+     * The free speed.
      */
-    val jointLimits: Limits
+    val freeSpeed: Double
 
     /**
-     * The [InertialStateEstimator].
+     * The free current.
      */
-    val inertialStateEstimator: InertialStateEstimator
+    val freeCurrent: Double
+
+    /**
+     * The stall torque.
+     */
+    val stallTorque: Double
+
+    /**
+     * The stall current.
+     */
+    val stallCurrent: Double
+
+    /**
+     * The maximum power output.
+     */
+    val power: Double
 }

--- a/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/DefaultBallBearing.kt
+++ b/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/DefaultBallBearing.kt
@@ -1,0 +1,31 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.vitamins
+
+import com.google.common.collect.ImmutableMap
+import com.neuronrobotics.bowlerkernel.gitfs.GitFile
+
+data class DefaultBallBearing(
+    override val bore: Double,
+    override val width: Double,
+    override val length: Double,
+    override val height: Double,
+    override val weight: Double,
+    override val centerOfMass: CenterOfMass,
+    override val specs: ImmutableMap<String, Any>,
+    override val cadGenerator: GitFile
+) : BallBearing

--- a/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/DefaultBattery.kt
+++ b/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/DefaultBattery.kt
@@ -1,0 +1,34 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.vitamins
+
+import com.google.common.collect.ImmutableMap
+import com.neuronrobotics.bowlerkernel.gitfs.GitFile
+
+data class DefaultBattery(
+    override val voltage: Double,
+    override val current: Double,
+    override val dischargeRate: Double,
+    override val capacity: Double,
+    override val width: Double,
+    override val length: Double,
+    override val height: Double,
+    override val weight: Double,
+    override val centerOfMass: CenterOfMass,
+    override val specs: ImmutableMap<String, Any>,
+    override val cadGenerator: GitFile
+) : Battery

--- a/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/DefaultDCMotor.kt
+++ b/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/DefaultDCMotor.kt
@@ -1,0 +1,38 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.vitamins
+
+import com.google.common.collect.ImmutableMap
+import com.neuronrobotics.bowlerkernel.gitfs.GitFile
+import com.neuronrobotics.bowlerkernel.util.Limits
+
+data class DefaultDCMotor(
+    override val voltage: Limits,
+    override val outputShaftDiameter: Double,
+    override val freeSpeed: Double,
+    override val freeCurrent: Double,
+    override val stallTorque: Double,
+    override val stallCurrent: Double,
+    override val power: Double,
+    override val width: Double,
+    override val length: Double,
+    override val height: Double,
+    override val weight: Double,
+    override val centerOfMass: CenterOfMass,
+    override val specs: ImmutableMap<String, Any>,
+    override val cadGenerator: GitFile
+) : DCMotor

--- a/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/DefaultServo.kt
+++ b/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/DefaultServo.kt
@@ -1,0 +1,33 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.vitamins
+
+import com.google.common.collect.ImmutableMap
+import com.neuronrobotics.bowlerkernel.gitfs.GitFile
+
+data class DefaultServo(
+    override val voltage: Double,
+    override val stallTorque: Double,
+    override val speed: Double,
+    override val width: Double,
+    override val length: Double,
+    override val height: Double,
+    override val weight: Double,
+    override val centerOfMass: CenterOfMass,
+    override val specs: ImmutableMap<String, Any>,
+    override val cadGenerator: GitFile
+) : Servo

--- a/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/DefaultStepperMotor.kt
+++ b/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/DefaultStepperMotor.kt
@@ -1,0 +1,36 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.vitamins
+
+import com.google.common.collect.ImmutableMap
+import com.neuronrobotics.bowlerkernel.gitfs.GitFile
+
+data class DefaultStepperMotor(
+    override val shaftDiameter: Double,
+    override val nemaSize: Int,
+    override val voltage: Double,
+    override val holdingTorque: Double,
+    override val current: Double,
+    override val stepAngle: Double,
+    override val width: Double,
+    override val length: Double,
+    override val height: Double,
+    override val weight: Double,
+    override val centerOfMass: CenterOfMass,
+    override val specs: ImmutableMap<String, Any>,
+    override val cadGenerator: GitFile
+) : StepperMotor

--- a/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/Servo.kt
+++ b/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/Servo.kt
@@ -14,16 +14,28 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.neuronrobotics.bowlerkernel.kinematics.limb.model
+package com.neuronrobotics.bowlerkernel.vitamins
 
-import com.neuronrobotics.bowlerkernel.gitfs.GitFile
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.LinkType
-import com.neuronrobotics.bowlerkernel.util.Limits
+/**
+ * A hobby servo motor.
+ *
+ * Good things to put in [Vitamin.specs]:
+ *  - Any supported feedback
+ */
+interface Servo : Vitamin {
 
-data class LinkData(
-    val type: LinkType,
-    val dhParamData: DhParamData,
-    val jointLimits: Limits,
-    val jointAngleController: GitFile,
-    val inertialStateEstimator: GitFile
-)
+    /**
+     * The operating voltage.
+     */
+    val voltage: Double
+
+    /**
+     * The stall torque.
+     */
+    val stallTorque: Double
+
+    /**
+     * The operating speed.
+     */
+    val speed: Double
+}

--- a/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/StepperMotor.kt
+++ b/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/StepperMotor.kt
@@ -1,0 +1,56 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.vitamins
+
+/**
+ * A generic stepper motor.
+ *
+ * Good things to put in [Vitamin.specs]:
+ *  - Mounting holes (Vitamin for the screws and hole positions)
+ */
+interface StepperMotor : Vitamin {
+
+    /**
+     * The shaft diameter.
+     */
+    val shaftDiameter: Double
+
+    /**
+     * The NEMA size.
+     */
+    val nemaSize: Int
+
+    /**
+     * The nominal voltage.
+     */
+    val voltage: Double
+
+    /**
+     * The holding torque.
+     */
+    val holdingTorque: Double
+
+    /**
+     * The rated current.
+     */
+    val current: Double
+
+    /**
+     * The degrees per step.
+     */
+    val stepAngle: Double
+}

--- a/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/Vitamin.kt
+++ b/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/Vitamin.kt
@@ -44,6 +44,11 @@ interface Vitamin {
     val height: Double
 
     /**
+     * The weight of this Vitamin.
+     */
+    val weight: Double
+
+    /**
      * The center of mass.
      */
     val centerOfMass: CenterOfMass

--- a/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/Vitamin.kt
+++ b/bowler-kernel/vitamins/src/main/kotlin/com/neuronrobotics/bowlerkernel/vitamins/Vitamin.kt
@@ -1,0 +1,60 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.vitamins
+
+import com.google.common.collect.ImmutableMap
+import com.neuronrobotics.bowlerkernel.gitfs.GitFile
+
+/**
+ * A Vitamin is typically something which cannot be 3d-printed; the electrical and hardware
+ * components of a robot that you can buy from a store can typically be modeled as Vitamins.
+ */
+interface Vitamin {
+
+    /**
+     * The overall width, not including keep-away zones for CAD. The frame this is measured from
+     * is arbitrary.
+     */
+    val width: Double
+
+    /**
+     * The overall length, not including keep-away zones for CAD. The frame this is measured from
+     * is arbitrary.
+     */
+    val length: Double
+
+    /**
+     * The overall height, not including keep-away zones for CAD. The frame this is measured from
+     * is arbitrary.
+     */
+    val height: Double
+
+    /**
+     * The center of mass.
+     */
+    val centerOfMass: CenterOfMass
+
+    /**
+     * Any extra specifications that the human interacting with this Vitamin might want to know.
+     */
+    val specs: ImmutableMap<String, Any>
+
+    /**
+     * The CAD generator.
+     */
+    val cadGenerator: GitFile
+}

--- a/bowler-kernel/vitamins/vitamins.gradle.kts
+++ b/bowler-kernel/vitamins/vitamins.gradle.kts
@@ -1,0 +1,8 @@
+description = "This module supports Vitamins."
+
+dependencies {
+    api(project(":bowler-kernel:gitfs"))
+    api(project(":bowler-kernel:util"))
+
+    implementation(group = "org.octogonapus", name = "kt-guava-core", version = "0.0.5")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,12 +8,14 @@ buildCache {
 rootProject.name = "bowler-kernel"
 
 include(":bowler-kernel")
+include(":bowler-kernel:config")
 include(":bowler-kernel:gitfs")
 include(":bowler-kernel:hardware")
 include(":bowler-kernel:kinematics")
 include(":bowler-kernel:logging")
 include(":bowler-kernel:scripting")
-include(":bowler-kernel:config")
+include(":bowler-kernel:util")
+include(":bowler-kernel:vitamins")
 
 /**
  * This configures the gradle build so we can use non-standard build file names.


### PR DESCRIPTION
### Description of the Change

This PR adds the `Vitamin` interface and a few other generic vitamins interfaces (`BallBearing`, `Servo`, etc.). I don't intent this to be all the vitamins we support, but it should be a good enough as a proof-of-concept to get the base vitamins layer sorted out.

### Motivation

Vitamins are an important part of the old stack; I also need this for work I am doing this summer.

### Possible Drawbacks

N/A

### Verification Process

I haven't added any functionality yet, just interfaces (and some backing data classes), so nothing to test yet.

### Applicable Issues

Closes #15.
