### PR TITLE
Move to SLF4J

### DIFF
--- a/bowler-kernel/gitfs/src/main/kotlin/com/neuronrobotics/bowlerkernel/gitfs/GitHubFS.kt
+++ b/bowler-kernel/gitfs/src/main/kotlin/com/neuronrobotics/bowlerkernel/gitfs/GitHubFS.kt
@@ -21,11 +21,11 @@ import arrow.core.Try.Companion.raiseError
 import arrow.core.handleErrorWith
 import com.google.common.base.Throwables
 import com.google.common.collect.ImmutableList
-import com.neuronrobotics.bowlerkernel.internal.logging.LoggerUtilities
 import com.neuronrobotics.bowlerkernel.settings.BOWLERKERNEL_DIRECTORY
 import com.neuronrobotics.bowlerkernel.settings.BOWLER_DIRECTORY
 import com.neuronrobotics.bowlerkernel.settings.GITHUB_CACHE_DIRECTORY
 import com.neuronrobotics.bowlerkernel.settings.GIT_CACHE_DIRECTORY
+import mu.KotlinLogging
 import org.apache.commons.io.FileUtils
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
@@ -53,7 +53,7 @@ class GitHubFS(
         gitUrl: String,
         branch: String
     ): Try<File> {
-        LOGGER.fine {
+        LOGGER.debug {
             """
             |Cloning repository:
             |gitUrl: $gitUrl
@@ -153,7 +153,7 @@ class GitHubFS(
                 ).toFile()
             )
         } catch (e: IOException) {
-            LOGGER.severe {
+            LOGGER.error {
                 """
                 |Unable to delete the GitHub cache.
                 |${Throwables.getStackTraceAsString(e)}
@@ -171,7 +171,7 @@ class GitHubFS(
     private fun forkRepo(
         githubRepo: GitHubRepo
     ): Try<GHObject> {
-        LOGGER.fine {
+        LOGGER.debug {
             """
             |Forking repository:
             |$githubRepo
@@ -191,7 +191,7 @@ class GitHubFS(
     }
 
     companion object {
-        private val LOGGER = LoggerUtilities.getLogger(GitHubFS::class.java.simpleName)
+        private val LOGGER = KotlinLogging.logger { }
 
         /**
          * Maps a file in a gist to its file on disk. Fails if the file is not on disk.

--- a/bowler-kernel/gitfs/src/main/kotlin/com/neuronrobotics/bowlerkernel/gitfs/GitHubFS.kt
+++ b/bowler-kernel/gitfs/src/main/kotlin/com/neuronrobotics/bowlerkernel/gitfs/GitHubFS.kt
@@ -19,7 +19,6 @@ package com.neuronrobotics.bowlerkernel.gitfs
 import arrow.core.Try
 import arrow.core.Try.Companion.raiseError
 import arrow.core.handleErrorWith
-import com.google.common.base.Throwables
 import com.google.common.collect.ImmutableList
 import com.neuronrobotics.bowlerkernel.settings.BOWLERKERNEL_DIRECTORY
 import com.neuronrobotics.bowlerkernel.settings.BOWLER_DIRECTORY
@@ -153,11 +152,8 @@ class GitHubFS(
                 ).toFile()
             )
         } catch (e: IOException) {
-            LOGGER.error {
-                """
-                |Unable to delete the GitHub cache.
-                |${Throwables.getStackTraceAsString(e)}
-                """.trimMargin()
+            LOGGER.error(e) {
+                "Unable to delete the GitHub cache."
             }
         }
     }

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/SimplePacketComsProtocol.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/SimplePacketComsProtocol.kt
@@ -32,10 +32,10 @@ import com.neuronrobotics.bowlerkernel.hardware.deviceresource.provisioned.nongr
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.ResourceId
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.ResourceIdValidator
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.ResourceType
-import com.neuronrobotics.bowlerkernel.internal.logging.LoggerUtilities
 import com.neuronrobotics.bowlerkernel.internal.logging.LoggerUtilities.Companion.joinWithIndent
 import edu.wpi.SimplePacketComs.AbstractSimpleComsDevice
 import edu.wpi.SimplePacketComs.BytePacketType
+import mu.KotlinLogging
 import org.octogonapus.ktguava.collections.toImmutableList
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
@@ -132,7 +132,7 @@ open class SimplePacketComsProtocol(
 
         val payloadWithHeader = byteArrayOf(operation) + payload
 
-        LOGGER.fine {
+        LOGGER.debug {
             """
             |Sent discovery payload:
             |${payload.joinToString()}
@@ -144,7 +144,7 @@ open class SimplePacketComsProtocol(
         discoveryPacket.oneShotMode()
         discoveryLatch.await()
 
-        LOGGER.fine {
+        LOGGER.debug {
             """
             |Discovery response:
             |${discoveryData.joinToString()}
@@ -262,7 +262,7 @@ open class SimplePacketComsProtocol(
         isPolling: Boolean,
         configureTimeoutBehavior: (BytePacketType) -> Unit
     ): Either<String, Unit> {
-        LOGGER.fine {
+        LOGGER.debug {
             """
             |Adding group:
             |resourceIds:
@@ -400,7 +400,7 @@ open class SimplePacketComsProtocol(
         isPolling: Boolean = false,
         configureTimeoutBehavior: (BytePacketType) -> Unit
     ): Either<String, Unit> {
-        LOGGER.fine {
+        LOGGER.debug {
             """
             |Adding resource:
             |resourceId: $resourceId
@@ -1072,8 +1072,7 @@ open class SimplePacketComsProtocol(
         const val STATUS_DISCARD_IN_PROGRESS = 10.toByte()
         const val STATUS_DISCARD_COMPLETE = 11.toByte()
 
-        private val LOGGER =
-            LoggerUtilities.getLogger(SimplePacketComsProtocol::class.java.simpleName)
+        private val LOGGER = KotlinLogging.logger { }
 
         /**
          * Computes whether the [testNumber] is outside the range of a unsigned byte.

--- a/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/SimplePacketComsProtocolReadGroupTest.kt
+++ b/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/SimplePacketComsProtocolReadGroupTest.kt
@@ -315,10 +315,12 @@ internal class SimplePacketComsProtocolReadGroupTest {
             }
         }
 
+        (1..254).map {
+            discoverGroupWithId(it.toByte())
+        }
+
         assertThrows<IllegalStateException> {
-            (1..300).map {
-                discoverGroupWithId(it.toByte())
-            }
+            discoverGroupWithId(255.toByte())
         }
     }
 

--- a/bowler-kernel/logging/logging.gradle.kts
+++ b/bowler-kernel/logging/logging.gradle.kts
@@ -5,5 +5,23 @@ plugins {
 description = "The kernel's logging tools."
 
 dependencies {
+    api(
+        group = "io.github.microutils",
+        name = "kotlin-logging",
+        version = property("kotlin-logging.version") as String
+    )
+
     implementation(project(":bowler-kernel:config"))
+
+    runtimeOnly(
+        group = "org.slf4j",
+        name = "slf4j-log4j12",
+        version = property("slf4j-log4j12.version") as String
+    )
+
+    runtimeOnly(
+        group = "log4j",
+        name = "apache-log4j-extras",
+        version = property("apache-log4j-extras.version") as String
+    )
 }

--- a/bowler-kernel/logging/src/main/kotlin/com/neuronrobotics/bowlerkernel/internal/logging/LoggerUtilities.kt
+++ b/bowler-kernel/logging/src/main/kotlin/com/neuronrobotics/bowlerkernel/internal/logging/LoggerUtilities.kt
@@ -16,89 +16,13 @@
  */
 package com.neuronrobotics.bowlerkernel.internal.logging
 
-import com.neuronrobotics.bowlerkernel.settings.BOWLERKERNEL_DIRECTORY
-import com.neuronrobotics.bowlerkernel.settings.BOWLER_DIRECTORY
-import com.neuronrobotics.bowlerkernel.settings.LOGS_DIRECTORY
-import java.io.File
-import java.io.IOException
-import java.nio.file.Paths
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-import java.util.logging.ConsoleHandler
-import java.util.logging.FileHandler
-import java.util.logging.Level
-import java.util.logging.Logger
-import java.util.logging.SimpleFormatter
-
 class LoggerUtilities private constructor() {
 
     init {
         throw UnsupportedOperationException("This is a utility class!")
     }
 
-    // We can'translate call a logger here instead because we are the logger!
-    @SuppressWarnings("PrintStackTrace")
     companion object {
-
-        // Log file parent directory path
-        private val logFileDirPath: String = Paths.get(
-            System.getProperty("user.home"),
-            BOWLER_DIRECTORY,
-            BOWLERKERNEL_DIRECTORY,
-            LOGS_DIRECTORY
-        ).toAbsolutePath().toString()
-
-        // Log file path
-        private val logFilePath: String = Paths.get(
-            logFileDirPath,
-            SimpleDateFormat("yyyyMMddHHmmss'.txt'", Locale("en", "US"))
-                .format(Date())
-        ).toAbsolutePath().toString()
-
-        // FileHandler that saves to the log file
-        private var fileHandler: FileHandler? = null
-
-        // Previous logger names
-        private val loggerNames = mutableSetOf<String>()
-
-        init {
-            val testFile = File(logFileDirPath)
-            try {
-                if (testFile.exists() || testFile.mkdirs()) {
-                    fileHandler = FileHandler(
-                        logFilePath, true
-                    )
-                    fileHandler!!.formatter = SimpleFormatter()
-                } else {
-                    throw IOException(
-                        "LoggerUtilities could not create the logging file: $logFilePath"
-                    )
-                }
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
-        /**
-         * Setup a logger with handlers and set its log level to [Level.ALL].
-         *
-         * @param name The logger name.
-         * @return The new logger.
-         */
-        fun getLogger(name: String): Logger {
-            if (!loggerNames.add(name)) {
-                throw UnsupportedOperationException(
-                    "Cannot add logger of name: $name. A logger with the same name already exists."
-                )
-            }
-
-            return Logger.getLogger(name).apply {
-                addHandler(ConsoleHandler())
-                addHandler(fileHandler!!)
-                level = Level.ALL
-            }
-        }
 
         /**
          * Calls [joinToString] with an indent applied to each separated line.

--- a/bowler-kernel/logging/src/main/resources/log4j.properties
+++ b/bowler-kernel/logging/src/main/resources/log4j.properties
@@ -3,10 +3,10 @@ log4j.rootLogger=DEBUG, stdout, file
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l%n%m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %t %l%n%m%n
 
 log4j.appender.file=org.apache.log4j.rolling.RollingFileAppender
 log4j.appender.file.RollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPolicy
 log4j.appender.file.RollingPolicy.FileNamePattern=${user.home}/Bowler/BowlerKernel/logs/kernel_%d{yyyyMMddHHmmss}.log
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l%n%m%n
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %t %l%n%m%n

--- a/bowler-kernel/logging/src/main/resources/log4j.properties
+++ b/bowler-kernel/logging/src/main/resources/log4j.properties
@@ -1,0 +1,12 @@
+log4j.rootLogger=DEBUG, stdout, file
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L%n%m%n
+
+log4j.appender.file=org.apache.log4j.rolling.RollingFileAppender
+log4j.appender.file.RollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPolicy
+log4j.appender.file.RollingPolicy.FileNamePattern=${user.home}/Bowler/BowlerKernel/logs/kernel_%d{yyyyMMddHHmmss}.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L%n%m%n

--- a/bowler-kernel/logging/src/main/resources/log4j.properties
+++ b/bowler-kernel/logging/src/main/resources/log4j.properties
@@ -3,10 +3,10 @@ log4j.rootLogger=DEBUG, stdout, file
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L%n%m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c:%L%n%m%n
 
 log4j.appender.file=org.apache.log4j.rolling.RollingFileAppender
 log4j.appender.file.RollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPolicy
 log4j.appender.file.RollingPolicy.FileNamePattern=${user.home}/Bowler/BowlerKernel/logs/kernel_%d{yyyyMMddHHmmss}.log
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L%n%m%n
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c:%L%n%m%n

--- a/bowler-kernel/logging/src/main/resources/log4j.properties
+++ b/bowler-kernel/logging/src/main/resources/log4j.properties
@@ -3,10 +3,10 @@ log4j.rootLogger=DEBUG, stdout, file
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c:%L%n%m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l%n%m%n
 
 log4j.appender.file=org.apache.log4j.rolling.RollingFileAppender
 log4j.appender.file.RollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPolicy
 log4j.appender.file.RollingPolicy.FileNamePattern=${user.home}/Bowler/BowlerKernel/logs/kernel_%d{yyyyMMddHHmmss}.log
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c:%L%n%m%n
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l%n%m%n

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,6 @@ klaxon.version=5.0.5
 kt-units.version=0.4.1
 commons-math3.version=3.6.1
 jama.version=1.0.3
+kotlin-logging.version=1.6.26
+slf4j-log4j12.version=1.7.26
+apache-log4j-extras.version=1.2.17


### PR DESCRIPTION
### Description of the Change

This PR replaces all the current logging with SLF4j (specifically, `kotlin-logging` which is an SLF4J wrapper) backed by log4j12.

### Motivation

The kernel's logging should be configurable by the API consumer.

### Possible Drawbacks

None.

### Verification Process

Manually verified by looking at console + file outputs and by including the kernel in a test project.

### Applicable Issues

None.
