### PR TITLE
Use IO in GitHubFS

### DIFF
--- a/bowler-kernel/gitfs/gitfs.gradle.kts
+++ b/bowler-kernel/gitfs/gitfs.gradle.kts
@@ -21,7 +21,14 @@ dependencies {
 
     api(project(":bowler-kernel:config"))
     api(project(":bowler-kernel:logging"))
+
     api(arrow("arrow-core-data"))
+    api(arrow("arrow-core-extensions"))
+    api(arrow("arrow-syntax"))
+    api(arrow("arrow-typeclasses"))
+    api(arrow("arrow-extras-data"))
+    api(arrow("arrow-extras-extensions"))
+    api(arrow("arrow-effects-extensions"))
 
     implementation(
         group = "org.eclipse.jgit",

--- a/bowler-kernel/gitfs/gitfs.gradle.kts
+++ b/bowler-kernel/gitfs/gitfs.gradle.kts
@@ -28,7 +28,9 @@ dependencies {
     api(arrow("arrow-typeclasses"))
     api(arrow("arrow-extras-data"))
     api(arrow("arrow-extras-extensions"))
+    api(arrow("arrow-effects-data"))
     api(arrow("arrow-effects-extensions"))
+    api(arrow("arrow-effects-io-extensions"))
 
     implementation(
         group = "org.eclipse.jgit",

--- a/bowler-kernel/gitfs/src/main/kotlin/com/neuronrobotics/bowlerkernel/gitfs/GitFS.kt
+++ b/bowler-kernel/gitfs/src/main/kotlin/com/neuronrobotics/bowlerkernel/gitfs/GitFS.kt
@@ -16,7 +16,7 @@
  */
 package com.neuronrobotics.bowlerkernel.gitfs
 
-import arrow.core.Try
+import arrow.effects.IO
 import com.google.common.collect.ImmutableList
 import java.io.File
 
@@ -34,7 +34,7 @@ interface GitFS {
      * @param branch The branch to checkout.
      * @return The directory of the cloned repository.
      */
-    fun cloneRepo(gitUrl: String, branch: String = "HEAD"): Try<File>
+    fun cloneRepo(gitUrl: String, branch: String = "HEAD"): IO<File>
 
     /**
      * Clones a repository and returns the files in it, excluding the `.git` files.
@@ -45,7 +45,7 @@ interface GitFS {
      * @param branch The branch to checkout.
      * @return The files in the repository.
      */
-    fun cloneRepoAndGetFiles(gitUrl: String, branch: String = "HEAD"): Try<ImmutableList<File>>
+    fun cloneRepoAndGetFiles(gitUrl: String, branch: String = "HEAD"): IO<ImmutableList<File>>
 
     /**
      * Forks a repository.
@@ -55,7 +55,7 @@ interface GitFS {
      * `https://gist.github.com/5681d11165708c3aec1ed5cf8cf38238.git`.
      * @return The git URL of the fork.
      */
-    fun forkRepo(gitUrl: String): Try<String>
+    fun forkRepo(gitUrl: String): IO<String>
 
     /**
      * Forks a repository and clones the fork.
@@ -66,7 +66,7 @@ interface GitFS {
      * @param branch The branch to checkout.
      * @return The directory of the cloned repository.
      */
-    fun forkAndCloneRepo(gitUrl: String, branch: String = "HEAD"): Try<File>
+    fun forkAndCloneRepo(gitUrl: String, branch: String = "HEAD"): IO<File>
 
     /**
      * Forks a repository, clones the fork, and returns the files in it, excluding the `.git`
@@ -81,14 +81,14 @@ interface GitFS {
     fun forkAndCloneRepoAndGetFiles(
         gitUrl: String,
         branch: String = "HEAD"
-    ): Try<ImmutableList<File>>
+    ): IO<ImmutableList<File>>
 
     /**
      * Returns whether the authenticated user has push access to the Git resource at [gitUrl].
      *
      * @param gitUrl
      */
-    fun isOwner(gitUrl: String): Try<Boolean>
+    fun isOwner(gitUrl: String): IO<Boolean>
 
     /**
      * Clears the local Git cache.

--- a/bowler-kernel/scripting/src/main/kotlin/com/neuronrobotics/bowlerkernel/scripting/factory/DefaultGitScriptFactory.kt
+++ b/bowler-kernel/scripting/src/main/kotlin/com/neuronrobotics/bowlerkernel/scripting/factory/DefaultGitScriptFactory.kt
@@ -41,11 +41,8 @@ class DefaultGitScriptFactory
     override fun createScriptFromGit(gitFile: GitFile): Either<String, Script> =
         gitFS.cloneRepoAndGetFiles(gitFile.gitUrl).map {
             val file = it.first { it.name == gitFile.filename }
-            val language = scriptLanguageParser.parse(file.extension)
-            language.map {
-                DefaultScript(it, file.readText())
-            }
-        }.toEither { it.localizedMessage }.flatMap { it }
+            scriptLanguageParser.parse(file.extension).map { DefaultScript(it, file.readText()) }
+        }.attempt().unsafeRunSync().mapLeft { it.localizedMessage }.flatMap { it }
 
     interface Factory {
         fun create(gitFS: GitFS): DefaultGitScriptFactory

--- a/bowler-kernel/vitamins/src/test/kotlin/com/neuronrobotics/bowlerkernel/vitamins/vitaminsupplier/gitvitaminsupplier/GitVitaminSupplierFactoryTest.kt
+++ b/bowler-kernel/vitamins/src/test/kotlin/com/neuronrobotics/bowlerkernel/vitamins/vitaminsupplier/gitvitaminsupplier/GitVitaminSupplierFactoryTest.kt
@@ -16,7 +16,7 @@
  */
 package com.neuronrobotics.bowlerkernel.vitamins.vitaminsupplier.gitvitaminsupplier
 
-import arrow.core.Try
+import arrow.effects.IO
 import com.google.common.collect.ImmutableList
 import com.neuronrobotics.bowlerkernel.gitfs.GitFS
 import com.neuronrobotics.bowlerkernel.gitfs.GitFile
@@ -56,7 +56,7 @@ internal class GitVitaminSupplierFactoryTest {
     )
 
     private fun makeMockGitFS(files: ImmutableList<File>) =
-        mock<GitFS> { on { cloneRepoAndGetFiles(supplierFile.gitUrl) } doReturn Try { files } }
+        mock<GitFS> { on { cloneRepoAndGetFiles(supplierFile.gitUrl) } doReturn IO.just(files) }
 
     @Test
     fun `test loading vitamins`(@TempDir tempDir: File) {
@@ -112,9 +112,9 @@ internal class GitVitaminSupplierFactoryTest {
     @Test
     fun `test unable to clone repo`() {
         val mockGitFS = mock<GitFS> {
-            on { cloneRepoAndGetFiles(any(), any()) } doReturn Try {
-                throw IllegalStateException("Oops!")
-            }
+            on {
+                cloneRepoAndGetFiles(any(), any())
+            } doReturn IO.raiseError(IllegalStateException("Oops!"))
         }
 
         assertThrows<IllegalStateException> {


### PR DESCRIPTION
### Description of the Change

This PR replaces uses of `Try` with `IO` in `GitHubFS`. This PR also fixes a bug with `forkAndCloneRepo`.

### Motivation

`Try` should not be used for disk/networking operations.

### Possible Drawbacks

None.

### Verification Process

Cloning and forking were verified by hand.

### Applicable Issues

Closes #24.
