### PR TITLE
Use Eval.Later for gists and repos

### DIFF
--- a/bowler-kernel/gitfs/src/main/kotlin/com/neuronrobotics/bowlerkernel/gitfs/GitHubFS.kt
+++ b/bowler-kernel/gitfs/src/main/kotlin/com/neuronrobotics/bowlerkernel/gitfs/GitHubFS.kt
@@ -51,8 +51,8 @@ class GitHubFS(
     private val credentials: Pair<String, String>
 ) : GitFS {
 
-    private val myGists = Eval.later { gitHub.myself.listGists() }
-    private val myRepositories = Eval.later { gitHub.myself.listRepositories() }
+    private val myGists = Eval.later { gitHub.myself.listGists().toList() }
+    private val myRepositories = Eval.later { gitHub.myself.allRepositories.values }
 
     override fun cloneRepo(
         gitUrl: String,

--- a/bowler-kernel/gitfs/src/main/kotlin/com/neuronrobotics/bowlerkernel/gitfs/GitHubFS.kt
+++ b/bowler-kernel/gitfs/src/main/kotlin/com/neuronrobotics/bowlerkernel/gitfs/GitHubFS.kt
@@ -18,6 +18,7 @@
 
 package com.neuronrobotics.bowlerkernel.gitfs
 
+import arrow.core.Eval
 import arrow.effects.IO
 import arrow.effects.handleErrorWith
 import com.google.common.collect.ImmutableList
@@ -49,6 +50,9 @@ class GitHubFS(
     private val gitHub: GitHub,
     private val credentials: Pair<String, String>
 ) : GitFS {
+
+    private val myGists = Eval.later { gitHub.myself.listGists() }
+    private val myRepositories = Eval.later { gitHub.myself.listRepositories() }
 
     override fun cloneRepo(
         gitUrl: String,
@@ -167,12 +171,12 @@ class GitHubFS(
     ): IO<ImmutableList<File>> = forkAndCloneRepo(gitUrl, branch).mapToRepoFiles()
 
     override fun isOwner(gitUrl: String): IO<Boolean> = IO {
-        gitHub.myself.listGists().firstOrNull {
+        myGists.value.firstOrNull {
             it.gitPullUrl == gitUrl
         } != null
     }.handleErrorWith {
         IO {
-            gitHub.myself.listRepositories().first { repo ->
+            myRepositories.value.first { repo ->
                 repo.gitTransportUrl == gitUrl
             }.hasPushAccess()
         }


### PR DESCRIPTION
### Description of the Change

This PR memoizes the result of listing gists and repos using `Eval.Later`.

### Motivation

The Kohsuke's GitHub API makes API calls whenever listing gists or repos, so we should memoize the result to avoid repeated API calls.

### Possible Drawbacks

The memoized results could be stale. Reinstantiating the class would refresh them, though.

### Verification Process

This was not verified.

### Applicable Issues

Closes #23.
