### PR TITLE
Model kinematic structures as directed graphs

### DIFF
--- a/bowler-kernel.gradle.kts
+++ b/bowler-kernel.gradle.kts
@@ -93,6 +93,7 @@ allprojects {
         mavenCentral()
         maven("https://dl.bintray.com/octogonapus/maven-artifacts")
         maven("https://oss.sonatype.org/content/repositories/staging/")
+        maven("https://dl.bintray.com/47deg/helios")
     }
 
     // Configures the Jacoco tool version to be the same for all projects that have it applied.

--- a/bowler-kernel/gitfs/gitfs.gradle.kts
+++ b/bowler-kernel/gitfs/gitfs.gradle.kts
@@ -1,5 +1,10 @@
 plugins {
     `java-library`
+    kotlin("kapt")
+}
+
+apply {
+    from(rootProject.file("gradle/generated-kotlin-sources.gradle"))
 }
 
 description = "An interface to a Git-based filesystem."
@@ -36,5 +41,31 @@ dependencies {
         group = "org.eclipse.jgit",
         name = "org.eclipse.jgit",
         version = "5.2.0.201812061821-r"
+    )
+
+    implementation(
+        group = "com.47deg",
+        name = "helios-core",
+        version = property("helios.version") as String
+    )
+    implementation(
+        group = "com.47deg",
+        name = "helios-parser",
+        version = property("helios.version") as String
+    )
+    implementation(
+        group = "com.47deg",
+        name = "helios-optics",
+        version = property("helios.version") as String
+    )
+    kapt(
+        group = "com.47deg",
+        name = "helios-meta",
+        version = property("helios.version") as String
+    )
+    kapt(
+        group = "com.47deg",
+        name = "helios-dsl-meta",
+        version = property("helios.version") as String
     )
 }

--- a/bowler-kernel/gitfs/src/main/kotlin/com/neuronrobotics/bowlerkernel/gitfs/GitFile.kt
+++ b/bowler-kernel/gitfs/src/main/kotlin/com/neuronrobotics/bowlerkernel/gitfs/GitFile.kt
@@ -16,6 +16,8 @@
  */
 package com.neuronrobotics.bowlerkernel.gitfs
 
+import helios.json
+
 /**
  * Represents a file in Git.
  *
@@ -24,7 +26,10 @@ package com.neuronrobotics.bowlerkernel.gitfs
  * `https://gist.github.com/5681d11165708c3aec1ed5cf8cf38238.git`.
  * @param filename The name of the file in the repo (including extension).
  */
+@json
 data class GitFile(
     val gitUrl: String,
     val filename: String
-)
+) {
+    companion object
+}

--- a/bowler-kernel/kinematics/kinematics.gradle.kts
+++ b/bowler-kernel/kinematics/kinematics.gradle.kts
@@ -1,3 +1,11 @@
+plugins {
+    kotlin("kapt")
+}
+
+apply {
+    from(rootProject.file("gradle/generated-kotlin-sources.gradle"))
+}
+
 description = "The kinematics stack."
 
 repositories {
@@ -48,10 +56,37 @@ dependencies {
         name = "kotlin-guiced-core",
         version = property("kotlin-guiced-core.version") as String
     )
+
     implementation(
         group = "com.beust",
         name = "klaxon",
         version = property("klaxon.version") as String
+    )
+
+    implementation(
+        group = "com.47deg",
+        name = "helios-core",
+        version = property("helios.version") as String
+    )
+    implementation(
+        group = "com.47deg",
+        name = "helios-parser",
+        version = property("helios.version") as String
+    )
+    implementation(
+        group = "com.47deg",
+        name = "helios-optics",
+        version = property("helios.version") as String
+    )
+    kapt(
+        group = "com.47deg",
+        name = "helios-meta",
+        version = property("helios.version") as String
+    )
+    kapt(
+        group = "com.47deg",
+        name = "helios-dsl-meta",
+        version = property("helios.version") as String
     )
 
     testImplementation(

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBase.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBase.kt
@@ -21,6 +21,8 @@ package com.neuronrobotics.bowlerkernel.kinematics.base
 import Jama.Matrix
 import arrow.core.Either
 import arrow.core.left
+import com.google.common.collect.ImmutableMap
+import com.google.common.collect.ImmutableSet
 import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.KinematicBaseId
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.BodyController
 import com.neuronrobotics.bowlerkernel.kinematics.graph.BaseNode
@@ -31,6 +33,8 @@ import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
 import com.neuronrobotics.bowlerkernel.kinematics.motion.MotionConstraints
 import org.octogonapus.ktguava.collections.outNodes
 import org.octogonapus.ktguava.collections.outNodesAndEdges
+import org.octogonapus.ktguava.collections.toImmutableMap
+import org.octogonapus.ktguava.collections.toImmutableSet
 
 /**
  * A [KinematicBase] which only considers limbs directly attached to it.
@@ -44,8 +48,8 @@ import org.octogonapus.ktguava.collections.outNodesAndEdges
 class DefaultKinematicBase(
     override val id: KinematicBaseId,
     override val bodyController: BodyController,
-    private val limbs: Set<Limb>,
-    private val limbBaseTransforms: Map<LimbId, FrameTransformation>
+    val limbs: ImmutableSet<Limb>,
+    val limbBaseTransforms: ImmutableMap<LimbId, FrameTransformation>
 ) : KinematicBase {
 
     private var currentWorldSpaceTransform = FrameTransformation.identity
@@ -129,8 +133,8 @@ class DefaultKinematicBase(
             return DefaultKinematicBase(
                 baseId,
                 bodyController,
-                limbs,
-                limbBaseTransforms
+                limbs.toImmutableSet(),
+                limbBaseTransforms.toImmutableMap()
             )
         }
     }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseFactory.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseFactory.kt
@@ -25,6 +25,7 @@ import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseScript
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.BodyController
 import com.neuronrobotics.bowlerkernel.kinematics.limb.LimbFactory
 import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
+import com.neuronrobotics.bowlerkernel.kinematics.motion.model.createInstance
 import com.neuronrobotics.bowlerkernel.scripting.factory.GitScriptFactory
 import org.octogonapus.ktguava.collections.toImmutableList
 import org.octogonapus.ktguava.collections.toImmutableMap

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseFactory.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseFactory.kt
@@ -19,7 +19,6 @@ package com.neuronrobotics.bowlerkernel.kinematics.base
 import arrow.core.Either
 import arrow.core.extensions.either.monad.binding
 import com.beust.klaxon.Klaxon
-import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.SimpleKinematicBaseId
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseConfigurationData
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseScriptData
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.BodyController
@@ -27,8 +26,6 @@ import com.neuronrobotics.bowlerkernel.kinematics.limb.LimbFactory
 import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
 import com.neuronrobotics.bowlerkernel.kinematics.motion.model.createInstance
 import com.neuronrobotics.bowlerkernel.scripting.factory.GitScriptFactory
-import org.octogonapus.ktguava.collections.toImmutableList
-import org.octogonapus.ktguava.collections.toImmutableMap
 import javax.inject.Inject
 
 class DefaultKinematicBaseFactory
@@ -45,20 +42,22 @@ class DefaultKinematicBaseFactory
         val (bodyController) = kinematicBaseScriptData.bodyController
             .createInstance<BodyController>(scriptFactory, klaxon)
 
-        val limbs = kinematicBaseConfigurationData.limbConfigurations
-            .zip(kinematicBaseScriptData.limbScripts)
-            .map { limbFactory.createLimb(it.first, it.second).bind() }
-            .toImmutableList()
+        TODO()
 
-        val limbTransforms = limbs.map { it.id }
-            .zip(kinematicBaseConfigurationData.limbTransforms)
-            .toImmutableMap()
-
-        DefaultKinematicBase(
-            SimpleKinematicBaseId(kinematicBaseConfigurationData.id),
-            limbs,
-            limbTransforms,
-            bodyController
-        )
+        // val limbs = kinematicBaseConfigurationData.limbConfigurations
+        //     .zip(kinematicBaseScriptData.limbScripts)
+        //     .map { limbFactory.createLimb(it.first, it.second).bind() }
+        //     .toImmutableList()
+        //
+        // val limbTransforms = limbs.map { it.id }
+        //     .zip(kinematicBaseConfigurationData.limbTransforms)
+        //     .toImmutableMap()
+        //
+        // DefaultKinematicBase(
+        //     SimpleKinematicBaseId(kinematicBaseConfigurationData.id),
+        //     limbs,
+        //     limbTransforms,
+        //     bodyController
+        // )
     }
 }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseFactory.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseFactory.kt
@@ -30,6 +30,8 @@ import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbScriptData
 import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
 import com.neuronrobotics.bowlerkernel.kinematics.motion.model.createInstance
 import com.neuronrobotics.bowlerkernel.scripting.factory.GitScriptFactory
+import org.octogonapus.ktguava.collections.toImmutableMap
+import org.octogonapus.ktguava.collections.toImmutableSet
 import javax.inject.Inject
 
 class DefaultKinematicBaseFactory
@@ -55,8 +57,8 @@ class DefaultKinematicBaseFactory
         DefaultKinematicBase(
             SimpleKinematicBaseId(kinematicBaseConfigurationData.id),
             bodyController,
-            limbs,
-            limbTransforms
+            limbs.toImmutableSet(),
+            limbTransforms.toImmutableMap()
         )
     }
 }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseFactory.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseFactory.kt
@@ -19,10 +19,14 @@ package com.neuronrobotics.bowlerkernel.kinematics.base
 import arrow.core.Either
 import arrow.core.extensions.either.monad.binding
 import com.beust.klaxon.Klaxon
+import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.SimpleKinematicBaseId
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseConfigurationData
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseScriptData
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.BodyController
 import com.neuronrobotics.bowlerkernel.kinematics.limb.LimbFactory
+import com.neuronrobotics.bowlerkernel.kinematics.limb.limbid.LimbId
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbConfigurationData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbScriptData
 import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
 import com.neuronrobotics.bowlerkernel.kinematics.motion.model.createInstance
 import com.neuronrobotics.bowlerkernel.scripting.factory.GitScriptFactory
@@ -37,27 +41,22 @@ class DefaultKinematicBaseFactory
 
     override fun create(
         kinematicBaseConfigurationData: KinematicBaseConfigurationData,
-        kinematicBaseScriptData: KinematicBaseScriptData
+        kinematicBaseScriptData: KinematicBaseScriptData,
+        limbData: List<Pair<LimbConfigurationData, LimbScriptData>>,
+        limbTransforms: Map<LimbId, FrameTransformation>
     ): Either<String, KinematicBase> = binding {
         val (bodyController) = kinematicBaseScriptData.bodyController
             .createInstance<BodyController>(scriptFactory, klaxon)
 
-        TODO()
+        val limbs = limbData.mapTo(hashSetOf()) {
+            limbFactory.createLimb(it.first, it.second).bind()
+        }
 
-        // val limbs = kinematicBaseConfigurationData.limbConfigurations
-        //     .zip(kinematicBaseScriptData.limbScripts)
-        //     .map { limbFactory.createLimb(it.first, it.second).bind() }
-        //     .toImmutableList()
-        //
-        // val limbTransforms = limbs.map { it.id }
-        //     .zip(kinematicBaseConfigurationData.limbTransforms)
-        //     .toImmutableMap()
-        //
-        // DefaultKinematicBase(
-        //     SimpleKinematicBaseId(kinematicBaseConfigurationData.id),
-        //     limbs,
-        //     limbTransforms,
-        //     bodyController
-        // )
+        DefaultKinematicBase(
+            SimpleKinematicBaseId(kinematicBaseConfigurationData.id),
+            bodyController,
+            limbs,
+            limbTransforms
+        )
     }
 }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/GeneralKinematicBase.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/GeneralKinematicBase.kt
@@ -1,0 +1,79 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.kinematics.base
+
+import Jama.Matrix
+import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.KinematicBaseId
+import com.neuronrobotics.bowlerkernel.kinematics.closedloop.BodyController
+import com.neuronrobotics.bowlerkernel.kinematics.graph.KinematicGraph
+import com.neuronrobotics.bowlerkernel.kinematics.limb.limbid.LimbId
+import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
+import com.neuronrobotics.bowlerkernel.kinematics.motion.InertialState
+import com.neuronrobotics.bowlerkernel.kinematics.motion.MotionConstraints
+
+/**
+ * A [KinematicBase] which uses all bases and limbs in the graph.
+ *
+ * @param id The id of this base.
+ * @param bodyController The body controller this base uses.
+ * @param kinematicGraph The kinematic graph containing the base and any other bases or limbs.
+ */
+class GeneralKinematicBase(
+    override val id: KinematicBaseId,
+    override val bodyController: BodyController,
+    private val kinematicGraph: KinematicGraph
+) : KinematicBase {
+
+    override fun setDesiredWorldSpaceTransformDelta(
+        worldSpaceTransform: FrameTransformation,
+        motionConstraints: MotionConstraints
+    ) {
+        TODO("not implemented")
+    }
+
+    override fun setCurrentWorldSpaceTransform(worldSpaceTransform: FrameTransformation) {
+        TODO("not implemented")
+    }
+
+    override fun getCurrentWorldSpaceTransformWithDelta(): FrameTransformation {
+        TODO("not implemented")
+    }
+
+    override fun setDesiredLimbTipTransform(
+        limbId: LimbId,
+        worldSpaceTransform: FrameTransformation,
+        motionConstraints: MotionConstraints
+    ) {
+        TODO("not implemented")
+    }
+
+    override fun getCurrentLimbTipTransform(limbId: LimbId): FrameTransformation {
+        TODO("not implemented")
+    }
+
+    override fun getDesiredLimbTipTransform(limbId: LimbId): FrameTransformation {
+        TODO("not implemented")
+    }
+
+    override fun computeJacobian(limbId: LimbId, linkIndex: Int): Matrix {
+        TODO("not implemented")
+    }
+
+    override fun getInertialState(): InertialState {
+        TODO("not implemented")
+    }
+}

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/KinematicBase.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/KinematicBase.kt
@@ -17,10 +17,9 @@
 package com.neuronrobotics.bowlerkernel.kinematics.base
 
 import Jama.Matrix
-import com.google.common.collect.ImmutableList
-import com.google.common.collect.ImmutableMap
 import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.KinematicBaseId
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.BodyController
+import com.neuronrobotics.bowlerkernel.kinematics.graph.KinematicGraph
 import com.neuronrobotics.bowlerkernel.kinematics.limb.Limb
 import com.neuronrobotics.bowlerkernel.kinematics.limb.limbid.LimbId
 import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
@@ -40,15 +39,9 @@ interface KinematicBase {
     val id: KinematicBaseId
 
     /**
-     * The limbs attached to this base.
+     * The graph this base is a part of.
      */
-    val limbs: ImmutableList<Limb>
-
-    /**
-     * A mapping of a [Limb.id] to the [FrameTransformation] which moves its starting point to
-     * its mounting point on this base.
-     */
-    val limbBaseTransforms: ImmutableMap<LimbId, FrameTransformation>
+    val kinematicGraph: KinematicGraph
 
     /**
      * The controller for the body.
@@ -97,34 +90,12 @@ interface KinematicBase {
     )
 
     /**
-     * Sets a desired world space transform the limb tip should try to move to.
-     *
-     * @param limbIndex The index of the limb in [limbs].
-     * @param worldSpaceTransform The desired world space transform for the limb tip.
-     * @param motionConstraints The constraints on the motion to move from the current task
-     * space transform to the desired [worldSpaceTransform].
-     */
-    fun setDesiredLimbTipTransform(
-        limbIndex: Int,
-        worldSpaceTransform: FrameTransformation,
-        motionConstraints: MotionConstraints
-    )
-
-    /**
      * Reads the current tip transform of the limb in world space.
      *
      * @param limbId The id of the limb.
      * @return The current limb tip transform in world space.
      */
     fun getCurrentLimbTipTransform(limbId: LimbId): FrameTransformation
-
-    /**
-     * Reads the current tip transform of the limb in world space.
-     *
-     * @param limbIndex The index of the limb in [limbs].
-     * @return The current limb tip transform in world space.
-     */
-    fun getCurrentLimbTipTransform(limbIndex: Int): FrameTransformation
 
     /**
      * Reads the desired tip transform of the limb in world space.
@@ -135,21 +106,13 @@ interface KinematicBase {
     fun getDesiredLimbTipTransform(limbId: LimbId): FrameTransformation
 
     /**
-     * Reads the desired tip transform of the limb in world space.
-     *
-     * @param limbIndex The index of the limb in [limbs].
-     * @return The desired limb tip transform in world space.
-     */
-    fun getDesiredLimbTipTransform(limbIndex: Int): FrameTransformation
-
-    /**
      * Computes the current Jacobian matrix for the given link.
      *
-     * @param limbIndex The index of the limb in [limbs].
+     * @param limbId The id of the limb.
      * @param linkIndex The index of the link in [Limb.links].
      * @return The Jacobian matrix.
      */
-    fun computeJacobian(limbIndex: Int, linkIndex: Int): Matrix
+    fun computeJacobian(limbId: LimbId, linkIndex: Int): Matrix
 
     /**
      * Returns the current [InertialState] for this base.

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/KinematicBase.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/KinematicBase.kt
@@ -19,7 +19,6 @@ package com.neuronrobotics.bowlerkernel.kinematics.base
 import Jama.Matrix
 import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.KinematicBaseId
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.BodyController
-import com.neuronrobotics.bowlerkernel.kinematics.graph.KinematicGraph
 import com.neuronrobotics.bowlerkernel.kinematics.limb.Limb
 import com.neuronrobotics.bowlerkernel.kinematics.limb.limbid.LimbId
 import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
@@ -37,11 +36,6 @@ interface KinematicBase {
      * The unique id of this base.
      */
     val id: KinematicBaseId
-
-    /**
-     * The graph this base is a part of.
-     */
-    val kinematicGraph: KinematicGraph
 
     /**
      * The controller for the body.

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/KinematicBaseFactory.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/KinematicBaseFactory.kt
@@ -19,6 +19,10 @@ package com.neuronrobotics.bowlerkernel.kinematics.base
 import arrow.core.Either
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseConfigurationData
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseScriptData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.limbid.LimbId
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbConfigurationData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbScriptData
+import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
 
 interface KinematicBaseFactory {
 
@@ -27,10 +31,14 @@ interface KinematicBaseFactory {
      *
      * @param kinematicBaseConfigurationData The configuration data.
      * @param kinematicBaseScriptData The script data.
+     * @param limbData The data for all the limbs attached to the base.
+     * @param limbTransforms The base transforms for all the limbs attached to the base.
      * @return A new kinematic base.
      */
     fun create(
         kinematicBaseConfigurationData: KinematicBaseConfigurationData,
-        kinematicBaseScriptData: KinematicBaseScriptData
+        kinematicBaseScriptData: KinematicBaseScriptData,
+        limbData: List<Pair<LimbConfigurationData, LimbScriptData>>,
+        limbTransforms: Map<LimbId, FrameTransformation>
     ): Either<String, KinematicBase>
 }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/model/KinematicBaseConfigurationData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/model/KinematicBaseConfigurationData.kt
@@ -16,80 +16,11 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics.base.model
 
-import arrow.core.Either
-import arrow.core.extensions.either.applicative.applicative
-import arrow.core.fix
-import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbConfigurationData
-import com.neuronrobotics.bowlerkernel.kinematics.limb.model.decoder
-import com.neuronrobotics.bowlerkernel.kinematics.limb.model.encoder
-import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
-import helios.core.DecodingError
-import helios.core.JsObject
-import helios.core.Json
-import helios.core.KeyNotFound
-import helios.instances.ListDecoderInstance
-import helios.instances.ListEncoderInstance
-import helios.instances.decoder
-import helios.instances.encoder
-import helios.typeclasses.Decoder
-import helios.typeclasses.Encoder
+import helios.json
 
+@json
 data class KinematicBaseConfigurationData(
-    val id: String,
-    val limbConfigurations: List<LimbConfigurationData>,
-    val limbTransforms: List<FrameTransformation>
+    val id: String
 ) {
-    init {
-        require(limbConfigurations.size == limbTransforms.size) {
-            """
-            Must have an equal number of limb configurations and limb transforms.
-            Limb configurations size: $limbConfigurations
-            Limb transforms size: $limbTransforms
-            """.trimIndent()
-        }
-    }
-
     companion object
-}
-
-fun KinematicBaseConfigurationData.toJson(): Json = JsObject(mapOf(
-    "id" to String.encoder().run { id.encode() }
-    ,
-    "limbConfigurations" to ListEncoderInstance(LimbConfigurationData.encoder()).run { limbConfigurations.encode() }
-    ,
-    "limbTransforms" to ListEncoderInstance(FrameTransformation.encoder()).run { limbTransforms.encode() }
-))
-
-fun Json.Companion.toKinematicBaseConfigurationData(value: Json): Either<DecodingError, KinematicBaseConfigurationData> =
-    Either.applicative<DecodingError>().map(
-        value["id"].fold(
-            { Either.Left(KeyNotFound("id")) },
-            { String.decoder().run { decode(it) } }),
-        value["limbConfigurations"].fold({ Either.Left(KeyNotFound("limbConfigurations")) }, {
-            ListDecoderInstance(
-                LimbConfigurationData.decoder()
-            ).run { decode(it) }
-        }),
-        value["limbTransforms"].fold({ Either.Left(KeyNotFound("limbTransforms")) }, {
-            ListDecoderInstance(
-                FrameTransformation.decoder()
-            ).run { decode(it) }
-        })
-    ) { (id, limbConfigurations, limbTransforms) ->
-        KinematicBaseConfigurationData(
-            id = id,
-            limbConfigurations = limbConfigurations,
-            limbTransforms = limbTransforms
-        )
-    }.fix()
-
-fun KinematicBaseConfigurationData.Companion.encoder() = object :
-    Encoder<KinematicBaseConfigurationData> {
-    override fun KinematicBaseConfigurationData.encode(): Json = this.toJson()
-}
-
-fun KinematicBaseConfigurationData.Companion.decoder() = object :
-    Decoder<KinematicBaseConfigurationData> {
-    override fun decode(value: Json): Either<DecodingError, KinematicBaseConfigurationData> =
-        Json.toKinematicBaseConfigurationData(value)
 }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/model/KinematicBaseConfigurationData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/model/KinematicBaseConfigurationData.kt
@@ -16,11 +16,80 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics.base.model
 
+import arrow.core.Either
+import arrow.core.extensions.either.applicative.applicative
+import arrow.core.fix
 import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbConfigurationData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.decoder
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.encoder
 import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
+import helios.core.DecodingError
+import helios.core.JsObject
+import helios.core.Json
+import helios.core.KeyNotFound
+import helios.instances.ListDecoderInstance
+import helios.instances.ListEncoderInstance
+import helios.instances.decoder
+import helios.instances.encoder
+import helios.typeclasses.Decoder
+import helios.typeclasses.Encoder
 
 data class KinematicBaseConfigurationData(
     val id: String,
     val limbConfigurations: List<LimbConfigurationData>,
     val limbTransforms: List<FrameTransformation>
-)
+) {
+    init {
+        require(limbConfigurations.size == limbTransforms.size) {
+            """
+            Must have an equal number of limb configurations and limb transforms.
+            Limb configurations size: $limbConfigurations
+            Limb transforms size: $limbTransforms
+            """.trimIndent()
+        }
+    }
+
+    companion object
+}
+
+fun KinematicBaseConfigurationData.toJson(): Json = JsObject(mapOf(
+    "id" to String.encoder().run { id.encode() }
+    ,
+    "limbConfigurations" to ListEncoderInstance(LimbConfigurationData.encoder()).run { limbConfigurations.encode() }
+    ,
+    "limbTransforms" to ListEncoderInstance(FrameTransformation.encoder()).run { limbTransforms.encode() }
+))
+
+fun Json.Companion.toKinematicBaseConfigurationData(value: Json): Either<DecodingError, KinematicBaseConfigurationData> =
+    Either.applicative<DecodingError>().map(
+        value["id"].fold(
+            { Either.Left(KeyNotFound("id")) },
+            { String.decoder().run { decode(it) } }),
+        value["limbConfigurations"].fold({ Either.Left(KeyNotFound("limbConfigurations")) }, {
+            ListDecoderInstance(
+                LimbConfigurationData.decoder()
+            ).run { decode(it) }
+        }),
+        value["limbTransforms"].fold({ Either.Left(KeyNotFound("limbTransforms")) }, {
+            ListDecoderInstance(
+                FrameTransformation.decoder()
+            ).run { decode(it) }
+        })
+    ) { (id, limbConfigurations, limbTransforms) ->
+        KinematicBaseConfigurationData(
+            id = id,
+            limbConfigurations = limbConfigurations,
+            limbTransforms = limbTransforms
+        )
+    }.fix()
+
+fun KinematicBaseConfigurationData.Companion.encoder() = object :
+    Encoder<KinematicBaseConfigurationData> {
+    override fun KinematicBaseConfigurationData.encode(): Json = this.toJson()
+}
+
+fun KinematicBaseConfigurationData.Companion.decoder() = object :
+    Decoder<KinematicBaseConfigurationData> {
+    override fun decode(value: Json): Either<DecodingError, KinematicBaseConfigurationData> =
+        Json.toKinematicBaseConfigurationData(value)
+}

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/model/KinematicBaseScriptData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/model/KinematicBaseScriptData.kt
@@ -16,10 +16,69 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics.base.model
 
+import arrow.core.Either
+import arrow.core.extensions.either.applicative.applicative
+import arrow.core.fix
+import com.neuronrobotics.bowlerkernel.gitfs.GitFile
+import com.neuronrobotics.bowlerkernel.gitfs.decoder
+import com.neuronrobotics.bowlerkernel.gitfs.encoder
 import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbScriptData
-import com.neuronrobotics.bowlerkernel.kinematics.motion.model.ControllerSpecification
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.decoder
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.encoder
+import com.neuronrobotics.bowlerkernel.kinematics.motion.model.ClassData
+import com.neuronrobotics.bowlerkernel.kinematics.motion.model.decoder
+import com.neuronrobotics.bowlerkernel.kinematics.motion.model.encoder
+import helios.core.DecodingError
+import helios.core.JsObject
+import helios.core.Json
+import helios.core.KeyNotFound
+import helios.instances.ListDecoderInstance
+import helios.instances.ListEncoderInstance
+import helios.instances.decoder
+import helios.instances.encoder
+import helios.typeclasses.Decoder
+import helios.typeclasses.Encoder
 
 data class KinematicBaseScriptData(
-    val bodyController: ControllerSpecification,
+    val bodyController: Either<GitFile, ClassData>,
     val limbScripts: List<LimbScriptData>
-)
+) {
+    companion object
+}
+
+fun KinematicBaseScriptData.toJson(): Json = JsObject(mapOf(
+    "bodyController" to Either.encoder(
+        GitFile.encoder(),
+        ClassData.encoder()
+    ).run { bodyController.encode() }
+    ,
+    "limbScripts" to ListEncoderInstance(LimbScriptData.encoder()).run { limbScripts.encode() }
+))
+
+fun Json.Companion.toKinematicBaseScriptData(value: Json): Either<DecodingError, KinematicBaseScriptData> =
+    Either.applicative<DecodingError>().map(
+        value["bodyController"].fold(
+            { Either.Left(KeyNotFound("bodyController")) },
+            {
+                Either.decoder(
+                    GitFile.decoder(),
+                    ClassData.decoder()
+                ).run { decode(it) }
+            }),
+        value["limbScripts"].fold({ Either.Left(KeyNotFound("limbScripts")) }, {
+            ListDecoderInstance(
+                LimbScriptData.decoder()
+            ).run { decode(it) }
+        })
+    ) { (bodyController, limbScripts) ->
+        KinematicBaseScriptData(bodyController = bodyController, limbScripts = limbScripts)
+    }.fix()
+
+fun KinematicBaseScriptData.Companion.encoder() = object : Encoder<KinematicBaseScriptData> {
+    override fun KinematicBaseScriptData.encode(): Json = this.toJson()
+}
+
+fun KinematicBaseScriptData.Companion.decoder() = object : Decoder<KinematicBaseScriptData> {
+    override fun decode(value: Json): Either<DecodingError, KinematicBaseScriptData> =
+        Json.toKinematicBaseScriptData(value)
+}

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/model/KinematicBaseScriptData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/model/KinematicBaseScriptData.kt
@@ -17,14 +17,10 @@
 package com.neuronrobotics.bowlerkernel.kinematics.base.model
 
 import arrow.core.Either
-import arrow.core.extensions.either.applicative.applicative
 import arrow.core.fix
 import com.neuronrobotics.bowlerkernel.gitfs.GitFile
 import com.neuronrobotics.bowlerkernel.gitfs.decoder
 import com.neuronrobotics.bowlerkernel.gitfs.encoder
-import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbScriptData
-import com.neuronrobotics.bowlerkernel.kinematics.limb.model.decoder
-import com.neuronrobotics.bowlerkernel.kinematics.limb.model.encoder
 import com.neuronrobotics.bowlerkernel.kinematics.motion.model.ClassData
 import com.neuronrobotics.bowlerkernel.kinematics.motion.model.decoder
 import com.neuronrobotics.bowlerkernel.kinematics.motion.model.encoder
@@ -32,16 +28,13 @@ import helios.core.DecodingError
 import helios.core.JsObject
 import helios.core.Json
 import helios.core.KeyNotFound
-import helios.instances.ListDecoderInstance
-import helios.instances.ListEncoderInstance
 import helios.instances.decoder
 import helios.instances.encoder
 import helios.typeclasses.Decoder
 import helios.typeclasses.Encoder
 
 data class KinematicBaseScriptData(
-    val bodyController: Either<GitFile, ClassData>,
-    val limbScripts: List<LimbScriptData>
+    val bodyController: Either<GitFile, ClassData>
 ) {
     companion object
 }
@@ -51,28 +44,18 @@ fun KinematicBaseScriptData.toJson(): Json = JsObject(mapOf(
         GitFile.encoder(),
         ClassData.encoder()
     ).run { bodyController.encode() }
-    ,
-    "limbScripts" to ListEncoderInstance(LimbScriptData.encoder()).run { limbScripts.encode() }
 ))
 
 fun Json.Companion.toKinematicBaseScriptData(value: Json): Either<DecodingError, KinematicBaseScriptData> =
-    Either.applicative<DecodingError>().map(
-        value["bodyController"].fold(
-            { Either.Left(KeyNotFound("bodyController")) },
-            {
-                Either.decoder(
-                    GitFile.decoder(),
-                    ClassData.decoder()
-                ).run { decode(it) }
-            }),
-        value["limbScripts"].fold({ Either.Left(KeyNotFound("limbScripts")) }, {
-            ListDecoderInstance(
-                LimbScriptData.decoder()
-            ).run { decode(it) }
-        })
-    ) { (bodyController, limbScripts) ->
-        KinematicBaseScriptData(bodyController = bodyController, limbScripts = limbScripts)
-    }.fix()
+
+    value["bodyController"].fold({ Either.Left(KeyNotFound("bodyController")) }, {
+        Either.decoder(
+            GitFile.decoder(), ClassData.decoder()
+        ).run { decode(it) }
+    })
+        .map { bodyController ->
+            KinematicBaseScriptData(bodyController = bodyController)
+        }.fix()
 
 fun KinematicBaseScriptData.Companion.encoder() = object : Encoder<KinematicBaseScriptData> {
     override fun KinematicBaseScriptData.encode(): Json = this.toJson()

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/graph/KinematicGraph.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/graph/KinematicGraph.kt
@@ -1,0 +1,109 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+@file:Suppress("UnstableApiUsage")
+
+package com.neuronrobotics.bowlerkernel.kinematics.graph
+
+import arrow.core.Either
+import arrow.core.Tuple2
+import arrow.core.Tuple3
+import arrow.core.right
+import com.beust.klaxon.Klaxon
+import com.google.common.graph.ImmutableNetwork
+import com.google.common.graph.MutableNetwork
+import com.neuronrobotics.bowlerkernel.kinematics.base.KinematicBase
+import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.KinematicBaseId
+import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseConfigurationData
+import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseScriptData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.Limb
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.DhParamData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.LinkConfigurationData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.LinkScriptData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbConfigurationData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbScriptData
+import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
+import com.neuronrobotics.bowlerkernel.kinematics.motion.model.ClassData
+
+data class BaseNode(
+    val id: KinematicBaseId
+)
+
+typealias KinematicGraph = ImmutableNetwork<Either<BaseNode, Limb>, FrameTransformation>
+typealias MutableKinematicGraph = MutableNetwork<Either<BaseNode, Limb>, FrameTransformation>
+
+fun KinematicGraph.convertToKinematicGraphData(
+    bases: Set<KinematicBase>,
+    klaxon: Klaxon = Klaxon().converter(FrameTransformation)
+): KinematicGraphData {
+    val mappedNodes = nodes().map {
+        it to it.bimap(
+            { baseNode -> bases.first { it.id == baseNode.id } },
+            { it }
+        ).mapToKinematicGraphDataNode(klaxon)
+    }.toMap()
+
+    return KinematicGraphData(
+        mappedNodes.values.toList(),
+        fullEdges().map { (nodeU, nodeV, edge) ->
+            Tuple3(
+                mappedNodes[nodeU] ?: error(""),
+                mappedNodes[nodeV] ?: error(""),
+                edge
+            )
+        }
+    )
+}
+
+private fun Either<KinematicBase, Limb>.mapToKinematicGraphDataNode(
+    klaxon: Klaxon
+): KinematicGraphDataNode = bimap(
+    {
+        Tuple2(
+            KinematicBaseConfigurationData(it.id.toString()),
+            KinematicBaseScriptData(
+                ClassData.fromInstance(it.bodyController, klaxon).right()
+            )
+        )
+    },
+    { limb ->
+        Tuple2(
+            LimbConfigurationData(
+                limb.id.toString(),
+                limb.links.map { link ->
+                    LinkConfigurationData(link.type, DhParamData(link.dhParam))
+                }
+            ),
+            LimbScriptData(
+                ClassData.fromInstance(limb.forwardKinematicsSolver, klaxon).right(),
+                ClassData.fromInstance(limb.inverseKinematicsSolver, klaxon).right(),
+                ClassData.fromInstance(limb.reachabilityCalculator, klaxon).right(),
+                ClassData.fromInstance(limb.motionPlanGenerator, klaxon).right(),
+                ClassData.fromInstance(limb.motionPlanFollower, klaxon).right(),
+                ClassData.fromInstance(limb.inertialStateEstimator, klaxon).right(),
+                limb.links.mapIndexed { index, link ->
+                    LinkScriptData(
+                        ClassData.fromInstance(
+                            limb.jointAngleControllers[index],
+                            klaxon
+                        ).right(),
+                        ClassData.fromInstance(link.inertialStateEstimator, klaxon).right()
+                    )
+                }
+            )
+        )
+    }
+)

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/graph/KinematicGraph.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/graph/KinematicGraph.kt
@@ -25,6 +25,7 @@ import arrow.core.right
 import com.beust.klaxon.Klaxon
 import com.google.common.graph.ImmutableNetwork
 import com.google.common.graph.MutableNetwork
+import com.google.common.graph.NetworkBuilder
 import com.neuronrobotics.bowlerkernel.kinematics.base.KinematicBase
 import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.KinematicBaseId
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseConfigurationData
@@ -38,13 +39,32 @@ import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbScriptData
 import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
 import com.neuronrobotics.bowlerkernel.kinematics.motion.model.ClassData
 
-data class BaseNode(
-    val id: KinematicBaseId
-)
+/**
+ * An identifier of a [KinematicBase] in a [KinematicGraph].
+ *
+ * @param id The [KinematicBase.id].
+ */
+data class BaseNode(val id: KinematicBaseId)
 
 typealias KinematicGraph = ImmutableNetwork<Either<BaseNode, Limb>, FrameTransformation>
 typealias MutableKinematicGraph = MutableNetwork<Either<BaseNode, Limb>, FrameTransformation>
 
+/**
+ * @return An empty [MutableKinematicGraph].
+ */
+fun buildMutableKinematicGraph(): MutableKinematicGraph =
+    NetworkBuilder.directed()
+        .allowsParallelEdges(false)
+        .allowsSelfLoops(false)
+        .build()
+
+/**
+ * Converts a [KinematicGraph] to a [KinematicGraphData].
+ *
+ * @param bases The kinematic bases corresponding to the base nodes in the graph.
+ * @param klaxon The [Klaxon] instance used to map scripts to [ClassData].
+ * @return A [KinematicGraphData] representing this [KinematicGraph].
+ */
 fun KinematicGraph.convertToKinematicGraphData(
     bases: Set<KinematicBase>,
     klaxon: Klaxon = Klaxon().converter(FrameTransformation)

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/graph/KinematicGraphData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/graph/KinematicGraphData.kt
@@ -22,7 +22,6 @@ import arrow.core.Tuple3
 import arrow.core.extensions.either.applicative.applicative
 import arrow.core.extensions.either.monad.binding
 import arrow.core.fix
-import com.google.common.graph.ImmutableNetwork
 import com.google.common.graph.NetworkBuilder
 import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.SimpleKinematicBaseId
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseConfigurationData
@@ -46,6 +45,7 @@ import helios.instances.decoder
 import helios.instances.encoder
 import helios.typeclasses.Decoder
 import helios.typeclasses.Encoder
+import org.octogonapus.ktguava.collections.toImmutableNetwork
 
 typealias KinematicGraphDataNode = Either<
     Tuple2<KinematicBaseConfigurationData, KinematicBaseScriptData>,
@@ -94,7 +94,7 @@ data class KinematicGraphData(
                 )
             }
 
-            ImmutableNetwork.copyOf(mutableNetwork)
+            mutableNetwork.toImmutableNetwork()
         }
 
     companion object

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/graph/KinematicGraphData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/graph/KinematicGraphData.kt
@@ -1,0 +1,199 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.kinematics.graph
+
+import arrow.core.Either
+import arrow.core.Tuple2
+import arrow.core.Tuple3
+import arrow.core.extensions.either.applicative.applicative
+import arrow.core.extensions.either.monad.binding
+import arrow.core.fix
+import com.google.common.graph.ImmutableNetwork
+import com.google.common.graph.NetworkBuilder
+import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.SimpleKinematicBaseId
+import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseConfigurationData
+import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseScriptData
+import com.neuronrobotics.bowlerkernel.kinematics.base.model.decoder
+import com.neuronrobotics.bowlerkernel.kinematics.base.model.encoder
+import com.neuronrobotics.bowlerkernel.kinematics.limb.Limb
+import com.neuronrobotics.bowlerkernel.kinematics.limb.LimbFactory
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbConfigurationData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbScriptData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.decoder
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.encoder
+import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
+import helios.core.DecodingError
+import helios.core.JsObject
+import helios.core.Json
+import helios.core.KeyNotFound
+import helios.instances.ListDecoderInstance
+import helios.instances.ListEncoderInstance
+import helios.instances.decoder
+import helios.instances.encoder
+import helios.typeclasses.Decoder
+import helios.typeclasses.Encoder
+
+typealias KinematicGraphDataNode = Either<
+    Tuple2<KinematicBaseConfigurationData, KinematicBaseScriptData>,
+    Tuple2<LimbConfigurationData, LimbScriptData>>
+
+/**
+ * The data represented by a kinematic graph, plus the actual kinematic bases.
+ */
+data class KinematicGraphData(
+    val nodes: List<KinematicGraphDataNode>,
+    val edges: List<Tuple3<KinematicGraphDataNode, KinematicGraphDataNode, FrameTransformation>>
+) {
+
+    @Suppress("UnstableApiUsage")
+    fun convertToKinematicGraph(
+        limbFactory: LimbFactory
+    ): Either<String, KinematicGraph> =
+        binding {
+            val mutableNetwork = NetworkBuilder.directed()
+                .allowsParallelEdges(false)
+                .expectedNodeCount(nodes.size)
+                .expectedEdgeCount(edges.size)
+                .allowsSelfLoops(false)
+                .build<Either<BaseNode, Limb>, FrameTransformation>()
+
+            val mappedNodes = nodes.map {
+                it to it.bimap(
+                    {
+                        BaseNode(
+                            SimpleKinematicBaseId(
+                                it.a.id
+                            )
+                        )
+                    },
+                    {
+                        limbFactory.createLimb(it.a, it.b).bind()
+                    }
+                )
+            }.toMap()
+
+            edges.forEach { (nodeU, nodeV, edge) ->
+                mutableNetwork.addEdge(
+                    mappedNodes[nodeU] ?: error(""),
+                    mappedNodes[nodeV] ?: error(""),
+                    edge
+                )
+            }
+
+            ImmutableNetwork.copyOf(mutableNetwork)
+        }
+
+    companion object
+}
+
+fun KinematicGraphData.toJson(): Json = JsObject(mapOf(
+    "edges" to ListEncoderInstance(
+        Tuple3.encoder(
+            Either.encoder(
+                Tuple2.encoder(
+                    KinematicBaseConfigurationData.encoder(),
+                    KinematicBaseScriptData.encoder()
+                ),
+                Tuple2.encoder(
+                    LimbConfigurationData.encoder(),
+                    LimbScriptData.encoder()
+                )
+            ),
+            Either.encoder(
+                Tuple2.encoder(
+                    KinematicBaseConfigurationData.encoder(),
+                    KinematicBaseScriptData.encoder()
+                ),
+                Tuple2.encoder(
+                    LimbConfigurationData.encoder(),
+                    LimbScriptData.encoder()
+                )
+            ),
+            FrameTransformation.encoder()
+        )
+    ).run { edges.encode() },
+    "nodes" to ListEncoderInstance(
+        Either.encoder(
+            Tuple2.encoder(
+                KinematicBaseConfigurationData.encoder(),
+                KinematicBaseScriptData.encoder()
+            ),
+            Tuple2.encoder(
+                LimbConfigurationData.encoder(),
+                LimbScriptData.encoder()
+            )
+        )
+    ).run { nodes.encode() }
+))
+
+fun Json.Companion.toKinematicGraphData(value: Json): Either<DecodingError, KinematicGraphData> =
+    Either.applicative<DecodingError>().map(
+        value["edges"].fold({ Either.Left(KeyNotFound("edges")) }, {
+            ListDecoderInstance(
+                Tuple3.decoder(
+                    Either.decoder(
+                        Tuple2.decoder(
+                            KinematicBaseConfigurationData.decoder(),
+                            KinematicBaseScriptData.decoder()
+                        ),
+                        Tuple2.decoder(
+                            LimbConfigurationData.decoder(),
+                            LimbScriptData.decoder()
+                        )
+                    ),
+                    Either.decoder(
+                        Tuple2.decoder(
+                            KinematicBaseConfigurationData.decoder(),
+                            KinematicBaseScriptData.decoder()
+                        ),
+                        Tuple2.decoder(
+                            LimbConfigurationData.decoder(),
+                            LimbScriptData.decoder()
+                        )
+                    ),
+                    FrameTransformation.decoder()
+                )
+            ).run { decode(it) }
+        }),
+        value["nodes"].fold(
+            { Either.Left(KeyNotFound("nodes")) },
+            {
+                ListDecoderInstance(
+                    Either.decoder(
+                        Tuple2.decoder(
+                            KinematicBaseConfigurationData.decoder(),
+                            KinematicBaseScriptData.decoder()
+                        ),
+                        Tuple2.decoder(
+                            LimbConfigurationData.decoder(),
+                            LimbScriptData.decoder()
+                        )
+                    )
+                ).run { decode(it) }
+            })
+    ) { (edges, nodes) ->
+        KinematicGraphData(edges = edges, nodes = nodes)
+    }.fix()
+
+fun KinematicGraphData.Companion.encoder() = object : Encoder<KinematicGraphData> {
+    override fun KinematicGraphData.encode(): Json = this.toJson()
+}
+
+fun KinematicGraphData.Companion.decoder() = object : Decoder<KinematicGraphData> {
+    override fun decode(value: Json): Either<DecodingError, KinematicGraphData> =
+        Json.toKinematicGraphData(value)
+}

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/graph/NetworkUtil.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/graph/NetworkUtil.kt
@@ -14,26 +14,28 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.neuronrobotics.bowlerkernel.kinematics.limb.link.model
+package com.neuronrobotics.bowlerkernel.kinematics.graph
 
-import arrow.core.right
-import com.beust.klaxon.Klaxon
-import com.neuronrobotics.bowlerkernel.kinematics.linkScriptData
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
+import arrow.core.Tuple3
+import arrow.data.ListK
+import arrow.data.extensions.listk.applicative.applicative
+import arrow.data.fix
+import arrow.data.k
+import com.google.common.graph.Network
 
-internal class LinkScriptDataTest {
-
-    @Test
-    fun `test json conversion`() {
-        val klaxon = Klaxon()
-
-        val expected = klaxon.linkScriptData()
-
-        val decoded = with(LinkScriptData.encoder()) {
-            expected.encode()
-        }.decode(LinkScriptData.decoder())
-
-        assertEquals(expected.right(), decoded)
-    }
+@Suppress("UnstableApiUsage")
+fun <A, B> Network<A, B>.fullEdges(): Set<Tuple3<A, A, B>> {
+    val nodes = nodes().toList()
+    return ListK.applicative()
+        .tupled(nodes.k(), nodes.k())
+        .fix()
+        .mapNotNull { (nodeU, nodeV) ->
+            val edge = edgeConnecting(nodeU, nodeV)
+            if (edge.isPresent) {
+                Tuple3(nodeU, nodeV, edge.get())
+            } else {
+                null
+            }
+        }
+        .toSet()
 }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/DefaultLimb.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/DefaultLimb.kt
@@ -106,4 +106,34 @@ class DefaultLimb(
         reachabilityCalculator.isFrameTransformationReachable(taskSpaceTransform, links)
 
     override fun getInertialState() = inertialStateEstimator.getInertialState()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DefaultLimb) return false
+
+        if (id != other.id) return false
+        if (links != other.links) return false
+        if (forwardKinematicsSolver != other.forwardKinematicsSolver) return false
+        if (inverseKinematicsSolver != other.inverseKinematicsSolver) return false
+        if (reachabilityCalculator != other.reachabilityCalculator) return false
+        if (motionPlanGenerator != other.motionPlanGenerator) return false
+        if (motionPlanFollower != other.motionPlanFollower) return false
+        if (jointAngleControllers != other.jointAngleControllers) return false
+        if (inertialStateEstimator != other.inertialStateEstimator) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + links.hashCode()
+        result = 31 * result + forwardKinematicsSolver.hashCode()
+        result = 31 * result + inverseKinematicsSolver.hashCode()
+        result = 31 * result + reachabilityCalculator.hashCode()
+        result = 31 * result + motionPlanGenerator.hashCode()
+        result = 31 * result + motionPlanFollower.hashCode()
+        result = 31 * result + jointAngleControllers.hashCode()
+        result = 31 * result + inertialStateEstimator.hashCode()
+        return result
+    }
 }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/DefaultLimbFactory.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/DefaultLimbFactory.kt
@@ -47,6 +47,14 @@ class DefaultLimbFactory
         limbConfigurationData: LimbConfigurationData,
         limbScriptData: LimbScriptData
     ): Either<String, Limb> = binding {
+        require(limbConfigurationData.linkConfigurations.size == limbScriptData.linkScripts.size) {
+            """
+            Must have an equal number of link configurations and link scripts.
+            Link configurations size: ${limbConfigurationData.linkConfigurations.size}
+            Link scripts size: ${limbScriptData.linkScripts.size}
+            """.trimIndent()
+        }
+
         val links = limbConfigurationData.linkConfigurations
             .zip(limbScriptData.linkScripts)
             .map { linkFactory.createLink(it.first, it.second).bind() }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/DefaultLimbFactory.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/DefaultLimbFactory.kt
@@ -28,6 +28,7 @@ import com.neuronrobotics.bowlerkernel.kinematics.motion.ForwardKinematicsSolver
 import com.neuronrobotics.bowlerkernel.kinematics.motion.InertialStateEstimator
 import com.neuronrobotics.bowlerkernel.kinematics.motion.InverseKinematicsSolver
 import com.neuronrobotics.bowlerkernel.kinematics.motion.ReachabilityCalculator
+import com.neuronrobotics.bowlerkernel.kinematics.motion.model.createInstance
 import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.LimbMotionPlanFollower
 import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.LimbMotionPlanGenerator
 import com.neuronrobotics.bowlerkernel.scripting.factory.GitScriptFactory

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/DefaultLinkFactory.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/DefaultLinkFactory.kt
@@ -22,6 +22,7 @@ import com.beust.klaxon.Klaxon
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.LinkConfigurationData
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.LinkScriptData
 import com.neuronrobotics.bowlerkernel.kinematics.motion.InertialStateEstimator
+import com.neuronrobotics.bowlerkernel.kinematics.motion.model.createInstance
 import com.neuronrobotics.bowlerkernel.scripting.factory.GitScriptFactory
 import javax.inject.Inject
 

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/LinkType.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/LinkType.kt
@@ -16,9 +16,40 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics.limb.link
 
+import arrow.core.Either
+import arrow.core.Try
+import arrow.core.flatMap
+import helios.core.DecodingError
+import helios.core.JsString
+import helios.core.Json
+import helios.core.ObjectDecodingError
+import helios.core.StringDecodingError
+import helios.typeclasses.Decoder
+import helios.typeclasses.Encoder
+
 /**
  * The type of a link.
  */
 enum class LinkType {
-    Rotary, Prismatic
+    Rotary, Prismatic;
+    companion object
 }
+
+fun LinkType.Companion.encoder() = Enum.Companion.encoder<LinkType>()
+fun LinkType.Companion.deocder() = Enum.Companion.decoder<LinkType>()
+
+fun <E : Enum<E>> Enum.Companion.encoder(): Encoder<Enum<E>> = object : Encoder<Enum<E>> {
+    override fun Enum<E>.encode(): Json = JsString(name)
+}
+
+inline fun <reified E : Enum<E>> Enum.Companion.decoder(): Decoder<Enum<E>> =
+    object : Decoder<Enum<E>> {
+
+        override fun decode(value: Json): Either<DecodingError, Enum<E>> =
+            value.asJsString().toEither { StringDecodingError(value) }.flatMap {
+                Try {
+                    java.lang.Enum.valueOf(E::class.java, it.value.toString())
+                }.toEither { ObjectDecodingError(value) }
+            }
+
+    }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/LinkType.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/LinkType.kt
@@ -32,24 +32,24 @@ import helios.typeclasses.Encoder
  */
 enum class LinkType {
     Rotary, Prismatic;
+
     companion object
 }
 
 fun LinkType.Companion.encoder() = Enum.Companion.encoder<LinkType>()
-fun LinkType.Companion.deocder() = Enum.Companion.decoder<LinkType>()
+fun LinkType.Companion.decoder() = Enum.Companion.decoder<LinkType>()
 
 fun <E : Enum<E>> Enum.Companion.encoder(): Encoder<Enum<E>> = object : Encoder<Enum<E>> {
     override fun Enum<E>.encode(): Json = JsString(name)
 }
 
-inline fun <reified E : Enum<E>> Enum.Companion.decoder(): Decoder<Enum<E>> =
-    object : Decoder<Enum<E>> {
+inline fun <reified E : Enum<E>> Enum.Companion.decoder(): Decoder<E> =
+    object : Decoder<E> {
 
-        override fun decode(value: Json): Either<DecodingError, Enum<E>> =
+        override fun decode(value: Json): Either<DecodingError, E> =
             value.asJsString().toEither { StringDecodingError(value) }.flatMap {
                 Try {
                     java.lang.Enum.valueOf(E::class.java, it.value.toString())
                 }.toEither { ObjectDecodingError(value) }
             }
-
     }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/model/DhParamData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/model/DhParamData.kt
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.neuronrobotics.bowlerkernel.kinematics.limb.model
+package com.neuronrobotics.bowlerkernel.kinematics.limb.link.model
 
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DhParam
 import helios.json
@@ -31,6 +31,13 @@ data class DhParamData(
         theta.toDouble(),
         r.toDouble(),
         alpha.toDouble()
+    )
+
+    constructor(dhParam: DhParam) : this(
+        dhParam.d,
+        dhParam.theta,
+        dhParam.r,
+        dhParam.alpha
     )
 
     fun toDhParam() = DhParam(d, theta, r, alpha)

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/model/LinkConfigurationData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/model/LinkConfigurationData.kt
@@ -22,9 +22,6 @@ import arrow.core.fix
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.LinkType
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.decoder
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.encoder
-import com.neuronrobotics.bowlerkernel.kinematics.limb.model.DhParamData
-import com.neuronrobotics.bowlerkernel.kinematics.limb.model.decoder
-import com.neuronrobotics.bowlerkernel.kinematics.limb.model.encoder
 import helios.core.DecodingError
 import helios.core.JsObject
 import helios.core.Json
@@ -40,8 +37,7 @@ data class LinkConfigurationData(
 }
 
 fun LinkConfigurationData.toJson(): Json = JsObject(mapOf(
-    "dhParamData" to DhParamData.encoder().run { dhParamData.encode() }
-    ,
+    "dhParamData" to DhParamData.encoder().run { dhParamData.encode() },
     "type" to LinkType.encoder().run { type.encode() }
 ))
 

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/model/LinkConfigurationData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/model/LinkConfigurationData.kt
@@ -18,8 +18,12 @@ package com.neuronrobotics.bowlerkernel.kinematics.limb.link.model
 
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.LinkType
 import com.neuronrobotics.bowlerkernel.kinematics.limb.model.DhParamData
+import helios.json
 
+@json
 data class LinkConfigurationData(
     val type: LinkType,
     val dhParamData: DhParamData
-)
+) {
+    companion object
+}

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/model/LinkScriptData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/model/LinkScriptData.kt
@@ -45,8 +45,7 @@ fun LinkScriptData.toJson(): Json = JsObject(mapOf(
     "inertialStateEstimator" to Either.encoder(
         GitFile.encoder(),
         ClassData.encoder()
-    ).run { inertialStateEstimator.encode() }
-    ,
+    ).run { inertialStateEstimator.encode() },
     "jointAngleController" to Either.encoder(
         GitFile.encoder(),
         ClassData.encoder()

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/DhParamData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/DhParamData.kt
@@ -17,7 +17,9 @@
 package com.neuronrobotics.bowlerkernel.kinematics.limb.model
 
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DhParam
+import helios.json
 
+@json
 data class DhParamData(
     val d: Double,
     val theta: Double,
@@ -32,4 +34,6 @@ data class DhParamData(
     )
 
     fun toDhParam() = DhParam(d, theta, r, alpha)
+
+    companion object
 }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/LimbConfigurationData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/LimbConfigurationData.kt
@@ -16,9 +16,55 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics.limb.model
 
+import arrow.core.Either
+import arrow.core.extensions.either.applicative.applicative
+import arrow.core.fix
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.LinkConfigurationData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.decoder
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.encoder
+import helios.core.DecodingError
+import helios.core.JsObject
+import helios.core.Json
+import helios.core.KeyNotFound
+import helios.instances.ListDecoderInstance
+import helios.instances.ListEncoderInstance
+import helios.instances.decoder
+import helios.instances.encoder
+import helios.typeclasses.Decoder
+import helios.typeclasses.Encoder
 
 data class LimbConfigurationData(
     val id: String,
     val linkConfigurations: List<LinkConfigurationData>
-)
+) {
+    companion object
+}
+
+fun LimbConfigurationData.toJson(): Json = JsObject(mapOf(
+    "id" to String.encoder().run { id.encode() }
+    ,
+    "linkConfigurations" to ListEncoderInstance(LinkConfigurationData.encoder()).run { linkConfigurations.encode() }
+))
+
+fun Json.Companion.toLimbConfigurationData(value: Json): Either<DecodingError, LimbConfigurationData> =
+    Either.applicative<DecodingError>().map(
+        value["id"].fold(
+            { Either.Left(KeyNotFound("id")) },
+            { String.decoder().run { decode(it) } }),
+        value["linkConfigurations"].fold({ Either.Left(KeyNotFound("linkConfigurations")) }, {
+            ListDecoderInstance(
+                LinkConfigurationData.decoder()
+            ).run { decode(it) }
+        })
+    ) { (id, linkConfigurations) ->
+        LimbConfigurationData(id = id, linkConfigurations = linkConfigurations)
+    }.fix()
+
+fun LimbConfigurationData.Companion.encoder() = object : Encoder<LimbConfigurationData> {
+    override fun LimbConfigurationData.encode(): Json = this.toJson()
+}
+
+fun LimbConfigurationData.Companion.decoder() = object : Decoder<LimbConfigurationData> {
+    override fun decode(value: Json): Either<DecodingError, LimbConfigurationData> =
+        Json.toLimbConfigurationData(value)
+}

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/LimbConfigurationData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/LimbConfigurationData.kt
@@ -41,8 +41,7 @@ data class LimbConfigurationData(
 }
 
 fun LimbConfigurationData.toJson(): Json = JsObject(mapOf(
-    "id" to String.encoder().run { id.encode() }
-    ,
+    "id" to String.encoder().run { id.encode() },
     "linkConfigurations" to ListEncoderInstance(LinkConfigurationData.encoder()).run { linkConfigurations.encode() }
 ))
 

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/LimbScriptData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/LimbScriptData.kt
@@ -55,30 +55,24 @@ fun LimbScriptData.toJson(): Json = JsObject(mapOf(
     "forwardKinematicsSolver" to Either.encoder(
         GitFile.encoder(),
         ClassData.encoder()
-    ).run { forwardKinematicsSolver.encode() }
-    ,
+    ).run { forwardKinematicsSolver.encode() },
     "inertialStateEstimator" to Either.encoder(
         GitFile.encoder(),
         ClassData.encoder()
-    ).run { inertialStateEstimator.encode() }
-    ,
+    ).run { inertialStateEstimator.encode() },
     "inverseKinematicsSolver" to Either.encoder(
         GitFile.encoder(),
         ClassData.encoder()
-    ).run { inverseKinematicsSolver.encode() }
-    ,
+    ).run { inverseKinematicsSolver.encode() },
     "limbMotionPlanFollower" to Either.encoder(
         GitFile.encoder(),
         ClassData.encoder()
-    ).run { limbMotionPlanFollower.encode() }
-    ,
+    ).run { limbMotionPlanFollower.encode() },
     "limbMotionPlanGenerator" to Either.encoder(
         GitFile.encoder(),
         ClassData.encoder()
-    ).run { limbMotionPlanGenerator.encode() }
-    ,
-    "linkScripts" to ListEncoderInstance(LinkScriptData.encoder()).run { linkScripts.encode() }
-    ,
+    ).run { limbMotionPlanGenerator.encode() },
+    "linkScripts" to ListEncoderInstance(LinkScriptData.encoder()).run { linkScripts.encode() },
     "reachabilityCalculator" to Either.encoder(
         GitFile.encoder(),
         ClassData.encoder()

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/LimbScriptData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/LimbScriptData.kt
@@ -16,15 +16,142 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics.limb.model
 
+import arrow.core.Either
+import arrow.core.extensions.either.applicative.applicative
+import arrow.core.fix
+import com.neuronrobotics.bowlerkernel.gitfs.GitFile
+import com.neuronrobotics.bowlerkernel.gitfs.decoder
+import com.neuronrobotics.bowlerkernel.gitfs.encoder
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.LinkScriptData
-import com.neuronrobotics.bowlerkernel.kinematics.motion.model.ControllerSpecification
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.decoder
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.encoder
+import com.neuronrobotics.bowlerkernel.kinematics.motion.model.ClassData
+import com.neuronrobotics.bowlerkernel.kinematics.motion.model.decoder
+import com.neuronrobotics.bowlerkernel.kinematics.motion.model.encoder
+import helios.core.DecodingError
+import helios.core.JsObject
+import helios.core.Json
+import helios.core.KeyNotFound
+import helios.instances.ListDecoderInstance
+import helios.instances.ListEncoderInstance
+import helios.instances.decoder
+import helios.instances.encoder
+import helios.typeclasses.Decoder
+import helios.typeclasses.Encoder
 
 data class LimbScriptData(
-    val forwardKinematicsSolver: ControllerSpecification,
-    val inverseKinematicsSolver: ControllerSpecification,
-    val reachabilityCalculator: ControllerSpecification,
-    val limbMotionPlanGenerator: ControllerSpecification,
-    val limbMotionPlanFollower: ControllerSpecification,
-    val inertialStateEstimator: ControllerSpecification,
+    val forwardKinematicsSolver: Either<GitFile, ClassData>,
+    val inverseKinematicsSolver: Either<GitFile, ClassData>,
+    val reachabilityCalculator: Either<GitFile, ClassData>,
+    val limbMotionPlanGenerator: Either<GitFile, ClassData>,
+    val limbMotionPlanFollower: Either<GitFile, ClassData>,
+    val inertialStateEstimator: Either<GitFile, ClassData>,
     val linkScripts: List<LinkScriptData>
-)
+) {
+    companion object
+}
+
+fun LimbScriptData.toJson(): Json = JsObject(mapOf(
+    "forwardKinematicsSolver" to Either.encoder(
+        GitFile.encoder(),
+        ClassData.encoder()
+    ).run { forwardKinematicsSolver.encode() }
+    ,
+    "inertialStateEstimator" to Either.encoder(
+        GitFile.encoder(),
+        ClassData.encoder()
+    ).run { inertialStateEstimator.encode() }
+    ,
+    "inverseKinematicsSolver" to Either.encoder(
+        GitFile.encoder(),
+        ClassData.encoder()
+    ).run { inverseKinematicsSolver.encode() }
+    ,
+    "limbMotionPlanFollower" to Either.encoder(
+        GitFile.encoder(),
+        ClassData.encoder()
+    ).run { limbMotionPlanFollower.encode() }
+    ,
+    "limbMotionPlanGenerator" to Either.encoder(
+        GitFile.encoder(),
+        ClassData.encoder()
+    ).run { limbMotionPlanGenerator.encode() }
+    ,
+    "linkScripts" to ListEncoderInstance(LinkScriptData.encoder()).run { linkScripts.encode() }
+    ,
+    "reachabilityCalculator" to Either.encoder(
+        GitFile.encoder(),
+        ClassData.encoder()
+    ).run { reachabilityCalculator.encode() }
+))
+
+fun Json.Companion.toLimbScriptData(value: Json): Either<DecodingError, LimbScriptData> =
+    Either.applicative<DecodingError>().map(
+        value["forwardKinematicsSolver"].fold(
+            { Either.Left(KeyNotFound("forwardKinematicsSolver")) },
+            {
+                Either.decoder(
+                    GitFile.decoder(), ClassData.decoder()
+                ).run { decode(it) }
+            }),
+        value["inertialStateEstimator"].fold(
+            { Either.Left(KeyNotFound("inertialStateEstimator")) },
+            {
+                Either.decoder(
+                    GitFile.decoder(), ClassData.decoder()
+                ).run { decode(it) }
+            }),
+        value["inverseKinematicsSolver"].fold(
+            { Either.Left(KeyNotFound("inverseKinematicsSolver")) },
+            {
+                Either.decoder(
+                    GitFile.decoder(), ClassData.decoder()
+                ).run { decode(it) }
+            }),
+        value["limbMotionPlanFollower"].fold(
+            { Either.Left(KeyNotFound("limbMotionPlanFollower")) },
+            {
+                Either.decoder(
+                    GitFile.decoder(), ClassData.decoder()
+                ).run { decode(it) }
+            }),
+        value["limbMotionPlanGenerator"].fold(
+            { Either.Left(KeyNotFound("limbMotionPlanGenerator")) },
+            {
+                Either.decoder(
+                    GitFile.decoder(), ClassData.decoder()
+                ).run { decode(it) }
+            }),
+        value["linkScripts"].fold({ Either.Left(KeyNotFound("linkScripts")) }, {
+            ListDecoderInstance(
+                LinkScriptData.decoder()
+            ).run { decode(it) }
+        }),
+        value["reachabilityCalculator"].fold(
+            { Either.Left(KeyNotFound("reachabilityCalculator")) },
+            {
+                Either.decoder(
+                    GitFile.decoder(), ClassData.decoder()
+                ).run { decode(it) }
+            })
+    ) { (forwardKinematicsSolver, inertialStateEstimator, inverseKinematicsSolver,
+        limbMotionPlanFollower, limbMotionPlanGenerator, linkScripts, reachabilityCalculator) ->
+        LimbScriptData(
+            forwardKinematicsSolver = forwardKinematicsSolver,
+            inertialStateEstimator = inertialStateEstimator,
+            inverseKinematicsSolver = inverseKinematicsSolver,
+            limbMotionPlanFollower = limbMotionPlanFollower,
+            limbMotionPlanGenerator = limbMotionPlanGenerator,
+            linkScripts = linkScripts,
+            reachabilityCalculator = reachabilityCalculator
+        )
+    }.fix()
+
+fun LimbScriptData.Companion.encoder() = object : Encoder<LimbScriptData> {
+    override fun LimbScriptData.encode(): Json = this.toJson()
+}
+
+fun LimbScriptData.Companion.decoder() = object : Decoder<LimbScriptData> {
+    override fun decode(value: Json): Either<DecodingError, LimbScriptData> =
+        Json.toLimbScriptData(value)
+}

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/FrameTransformation.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/FrameTransformation.kt
@@ -373,6 +373,8 @@ private constructor(private val mat: Matrix) {
                 "data" to JsArray(internalData.map { JsNumber(it) })
             )
 
+        fun encoder() = this
+
         override fun decode(value: Json): Either<DecodingError, FrameTransformation> =
             Either.applicative<DecodingError>().map(
                 value["rows"].fold(
@@ -399,6 +401,8 @@ private constructor(private val mat: Matrix) {
                     )
                 )
             }.fix()
+
+        fun decoder() = this
     }
 }
 

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthBasedReachabilityCalculator.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthBasedReachabilityCalculator.kt
@@ -38,7 +38,5 @@ class LengthBasedReachabilityCalculator : ReachabilityCalculator {
         return true
     }
 
-    override fun hashCode(): Int {
-        return javaClass.hashCode()
-    }
+    override fun hashCode(): Int = javaClass.hashCode()
 }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthBasedReachabilityCalculator.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthBasedReachabilityCalculator.kt
@@ -31,4 +31,14 @@ class LengthBasedReachabilityCalculator : ReachabilityCalculator {
         links: ImmutableList<Link>
     ) = frameTransformation.translation.length() <=
         links.map { it.dhParam }.toFrameTransformation().translation.length()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is LengthBasedReachabilityCalculator) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
+    }
 }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/model/ClassData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/model/ClassData.kt
@@ -32,7 +32,7 @@ data class ClassData(
 
         fun fromInstance(instance: Any, klaxon: Klaxon) = ClassData(
             instance::class.qualifiedName!!,
-            klaxon.toJsonString(instance)
+            klaxon.toJsonString(instance).replace("\"", "\\\"")
         )
     }
 }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/model/ClassData.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/model/ClassData.kt
@@ -17,10 +17,12 @@
 package com.neuronrobotics.bowlerkernel.kinematics.motion.model
 
 import com.beust.klaxon.Klaxon
+import helios.json
 
 /**
  * All the data needed to instantiate a class.
  */
+@json
 data class ClassData(
     val fullClassName: String,
     val data: String

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/model/ControllerSpecification.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/model/ControllerSpecification.kt
@@ -59,7 +59,7 @@ inline fun <reified T : Any> ControllerSpecification.loadClass(klaxon: Klaxon): 
     }
 
     return klaxon.fromJsonObject(
-        klaxon.parseJsonObject(b.data.reader()),
+        klaxon.parseJsonObject(b.data.replace("\\\"", "\"").reader()),
         clazz,
         clazz.kotlin
     ) as T

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/model/ControllerSpecification.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/model/ControllerSpecification.kt
@@ -18,83 +18,66 @@ package com.neuronrobotics.bowlerkernel.kinematics.motion.model
 
 import arrow.core.Either
 import arrow.core.Try
-import arrow.core.left
-import arrow.core.right
 import com.beust.klaxon.Klaxon
 import com.google.common.base.Throwables
 import com.neuronrobotics.bowlerkernel.gitfs.GitFile
+import com.neuronrobotics.bowlerkernel.gitfs.decoder
+import com.neuronrobotics.bowlerkernel.gitfs.encoder
 import com.neuronrobotics.bowlerkernel.scripting.factory.GitScriptFactory
 import com.neuronrobotics.bowlerkernel.scripting.factory.getInstanceFromGit
+import helios.instances.decoder
+import helios.instances.encoder
 
 /**
  * A specification that can be resolved into a controller. Either a [GitFile] or a [ClassData] that
  * can be parsed into a class.
  */
-data class ControllerSpecification(
-    val gitFile: GitFile? = null,
-    val fullClassData: ClassData? = null
-) {
+typealias ControllerSpecification = Either<GitFile, ClassData>
 
-    init {
-        require((gitFile == null) xor (fullClassData == null))
+fun controllerSpecificationEncoder() =
+    ControllerSpecification.encoder(GitFile.encoder(), ClassData.encoder())
+
+fun controllerSpecificationDecoder() =
+    ControllerSpecification.decoder(GitFile.decoder(), ClassData.decoder())
+
+/**
+ * Looks up a class by name [ClassData.fullClassName] and parses it using [klaxon].
+ *
+ * @param klaxon The [Klaxon] instance to use to parse the class data.
+ * @return The parsed class.
+ */
+inline fun <reified T : Any> ControllerSpecification.loadClass(klaxon: Klaxon): T {
+    require(isRight()) {
+        "This ControllerSpecification must be Either.Right. Was:\n$this"
     }
 
-    /**
-     * @return This [ControllerSpecification] as an [Either].
-     */
-    fun toEither(): Either<GitFile, ClassData> =
-        gitFile?.left() ?: (fullClassData as ClassData).right()
+    this as Either.Right
 
-    /**
-     * Looks up a class by name [ClassData.fullClassName] and parses it using [klaxon].
-     *
-     * @param klaxon The [Klaxon] instance to use to parse the class data.
-     * @return The parsed class.
-     */
-    inline fun <reified T : Any> loadClass(klaxon: Klaxon): T {
-        require(fullClassData != null)
-
-        val clazz = Class.forName(fullClassData.fullClassName)
-        require(T::class.java.isAssignableFrom(clazz))
-
-        return klaxon.fromJsonObject(
-            klaxon.parseJsonObject(fullClassData.data.reader()),
-            clazz,
-            clazz.kotlin
-        ) as T
+    val clazz = Class.forName(b.fullClassName)
+    require(T::class.java.isAssignableFrom(clazz)) {
+        "${T::class.java.name} is not assignable from ${clazz.name}."
     }
 
-    /**
-     * Creates an instance from this whether this is a [gitFile] or a [fullClassData].
-     *
-     * @param scriptFactory The [GitScriptFactory] used if this is a [gitFile].
-     * @param klaxon The [Klaxon] used if this is a [fullClassData].
-     * @return The instance.
-     */
-    inline fun <reified T : Any> createInstance(
-        scriptFactory: GitScriptFactory,
-        klaxon: Klaxon
-    ): Either<String, T> {
-        return when (val either = toEither()) {
-            is Either.Left -> scriptFactory.getInstanceFromGit<T>(either.a).unsafeRunSync()
-            is Either.Right -> Try { loadClass<T>(klaxon) }.toEither {
-                Throwables.getStackTraceAsString(it)
-            }
-        }
-    }
+    return klaxon.fromJsonObject(
+        klaxon.parseJsonObject(b.data.reader()),
+        clazz,
+        clazz.kotlin
+    ) as T
+}
 
-    companion object {
-
-        /**
-         * Converts an [Either] into a [ControllerSpecification].
-         */
-        fun fromEither(either: Either<GitFile, ClassData>) = when (either) {
-            is Either.Left -> ControllerSpecification(gitFile = either.a)
-            is Either.Right -> ControllerSpecification(fullClassData = either.b)
-        }
-
-        fun fromGitFile(gitFile: GitFile) = ControllerSpecification(gitFile, null)
-
-        fun fromClassData(classData: ClassData) = ControllerSpecification(null, classData)
+/**
+ * Creates an instance from this.
+ *
+ * @param scriptFactory The [GitScriptFactory] used if this is a [Either.Left].
+ * @param klaxon The [Klaxon] used if this is a [Either.Right].
+ * @return The instance.
+ */
+inline fun <reified T : Any> ControllerSpecification.createInstance(
+    scriptFactory: GitScriptFactory,
+    klaxon: Klaxon
+): Either<String, T> = when (this) {
+    is Either.Left -> scriptFactory.getInstanceFromGit<T>(a).unsafeRunSync()
+    is Either.Right -> Try { loadClass<T>(klaxon) }.toEither {
+        Throwables.getStackTraceAsString(it)
     }
 }

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/ControlTestUtil.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/ControlTestUtil.kt
@@ -16,8 +16,27 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics
 
+import arrow.core.right
 import com.beust.klaxon.Klaxon
+import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseConfigurationData
+import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseScriptData
+import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopBodyController
+import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopJointAngleController
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.LinkType
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.LinkConfigurationData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.LinkScriptData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.DhParamData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbConfigurationData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbScriptData
 import com.neuronrobotics.bowlerkernel.kinematics.motion.BasicMotionConstraints
+import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
+import com.neuronrobotics.bowlerkernel.kinematics.motion.LengthBasedReachabilityCalculator
+import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopForwardKinematicsSolver
+import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopInertialStateEstimator
+import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopInverseKinematicsSolver
+import com.neuronrobotics.bowlerkernel.kinematics.motion.model.ClassData
+import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.NoopLimbMotionPlanFollower
+import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.NoopLimbMotionPlanGenerator
 import org.junit.jupiter.api.Assertions.assertEquals
 
 internal fun createMotionConstraints(duration: Number) = BasicMotionConstraints(
@@ -27,3 +46,81 @@ internal fun createMotionConstraints(duration: Number) = BasicMotionConstraints(
 internal inline fun <reified T> Klaxon.testJsonConversion(input: T) {
     assertEquals(input, parse<T>(toJsonString(input).also { println(it) }))
 }
+
+internal fun linkConfigurationData() = LinkConfigurationData(
+    LinkType.Rotary,
+    DhParamData(1, 2, 3, 4.5)
+)
+
+internal fun Klaxon.linkScriptData() = LinkScriptData(
+    ClassData.fromInstance(
+        NoopJointAngleController,
+        this
+    ).right(),
+    ClassData.fromInstance(
+        NoopInertialStateEstimator,
+        this
+    ).right()
+)
+
+internal fun limbConfigurationData() = LimbConfigurationData(
+    "A",
+    listOf(
+        linkConfigurationData(),
+        linkConfigurationData()
+    )
+)
+
+internal fun Klaxon.limbScriptData() = LimbScriptData(
+    ClassData.fromInstance(
+        NoopForwardKinematicsSolver,
+        this
+    ).right(),
+    ClassData.fromInstance(
+        NoopInverseKinematicsSolver,
+        this
+    ).right(),
+    ClassData.fromInstance(
+        LengthBasedReachabilityCalculator(),
+        this
+    ).right(),
+    ClassData.fromInstance(
+        NoopLimbMotionPlanGenerator,
+        this
+    ).right(),
+    ClassData.fromInstance(
+        NoopLimbMotionPlanFollower,
+        this
+    ).right(),
+    ClassData.fromInstance(
+        NoopInertialStateEstimator,
+        this
+    ).right(),
+    listOf(
+        linkScriptData(),
+        linkScriptData()
+    )
+)
+
+internal fun Klaxon.kinematicBaseScriptData() = KinematicBaseScriptData(
+    ClassData.fromInstance(
+        NoopBodyController,
+        this
+    ).right(),
+    listOf(
+        limbScriptData(),
+        limbScriptData()
+    )
+)
+
+internal fun kinematicBaseConfigurationData() = KinematicBaseConfigurationData(
+    "A",
+    listOf(
+        limbConfigurationData(),
+        limbConfigurationData()
+    ),
+    listOf(
+        FrameTransformation.fromTranslation(10, 20, 30),
+        FrameTransformation.identity
+    )
+)

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/ControlTestUtil.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/ControlTestUtil.kt
@@ -16,13 +16,19 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics
 
+import arrow.core.left
 import arrow.core.right
 import com.beust.klaxon.Klaxon
 import com.google.common.collect.ImmutableList
+import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.KinematicBaseId
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseConfigurationData
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseScriptData
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopBodyController
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopJointAngleController
+import com.neuronrobotics.bowlerkernel.kinematics.graph.BaseNode
+import com.neuronrobotics.bowlerkernel.kinematics.graph.KinematicGraph
+import com.neuronrobotics.bowlerkernel.kinematics.graph.buildMutableKinematicGraph
+import com.neuronrobotics.bowlerkernel.kinematics.limb.Limb
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DefaultLink
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DhParam
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.Link
@@ -33,6 +39,7 @@ import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.LinkScriptData
 import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbConfigurationData
 import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbScriptData
 import com.neuronrobotics.bowlerkernel.kinematics.motion.BasicMotionConstraints
+import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
 import com.neuronrobotics.bowlerkernel.kinematics.motion.LengthBasedReachabilityCalculator
 import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopForwardKinematicsSolver
 import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopInertialStateEstimator
@@ -42,6 +49,7 @@ import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.NoopLimbMotionPlan
 import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.NoopLimbMotionPlanGenerator
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.octogonapus.ktguava.collections.immutableListOf
+import org.octogonapus.ktguava.collections.toImmutableNetwork
 
 internal fun createMotionConstraints(duration: Number) = BasicMotionConstraints(
     duration, 0, 0, 0
@@ -134,3 +142,16 @@ internal val seaArmLinks: ImmutableList<Link> = immutableListOf(
         NoopInertialStateEstimator
     )
 )
+
+internal fun makeSimpleKinematicGraph(
+    baseId: KinematicBaseId,
+    vararg limbs: Pair<Limb, FrameTransformation>
+): KinematicGraph {
+    val mutableGraph = buildMutableKinematicGraph()
+
+    limbs.forEach { (limb, transform) ->
+        mutableGraph.addEdge(BaseNode(baseId).left(), limb.right(), transform)
+    }
+
+    return mutableGraph.toImmutableNetwork()
+}

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/ControlTestUtil.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/ControlTestUtil.kt
@@ -18,18 +18,21 @@ package com.neuronrobotics.bowlerkernel.kinematics
 
 import arrow.core.right
 import com.beust.klaxon.Klaxon
+import com.google.common.collect.ImmutableList
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseConfigurationData
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseScriptData
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopBodyController
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopJointAngleController
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DefaultLink
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DhParam
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.Link
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.LinkType
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.DhParamData
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.LinkConfigurationData
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.LinkScriptData
-import com.neuronrobotics.bowlerkernel.kinematics.limb.model.DhParamData
 import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbConfigurationData
 import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbScriptData
 import com.neuronrobotics.bowlerkernel.kinematics.motion.BasicMotionConstraints
-import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
 import com.neuronrobotics.bowlerkernel.kinematics.motion.LengthBasedReachabilityCalculator
 import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopForwardKinematicsSolver
 import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopInertialStateEstimator
@@ -38,6 +41,7 @@ import com.neuronrobotics.bowlerkernel.kinematics.motion.model.ClassData
 import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.NoopLimbMotionPlanFollower
 import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.NoopLimbMotionPlanGenerator
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.octogonapus.ktguava.collections.immutableListOf
 
 internal fun createMotionConstraints(duration: Number) = BasicMotionConstraints(
     duration, 0, 0, 0
@@ -106,21 +110,27 @@ internal fun Klaxon.kinematicBaseScriptData() = KinematicBaseScriptData(
     ClassData.fromInstance(
         NoopBodyController,
         this
-    ).right(),
-    listOf(
-        limbScriptData(),
-        limbScriptData()
-    )
+    ).right()
 )
 
 internal fun kinematicBaseConfigurationData() = KinematicBaseConfigurationData(
-    "A",
-    listOf(
-        limbConfigurationData(),
-        limbConfigurationData()
+    "A"
+)
+
+internal val seaArmLinks: ImmutableList<Link> = immutableListOf(
+    DefaultLink(
+        LinkType.Rotary,
+        DhParam(135, 0, 0, -90),
+        NoopInertialStateEstimator
     ),
-    listOf(
-        FrameTransformation.fromTranslation(10, 20, 30),
-        FrameTransformation.identity
+    DefaultLink(
+        LinkType.Rotary,
+        DhParam(0, 0, 175, 0),
+        NoopInertialStateEstimator
+    ),
+    DefaultLink(
+        LinkType.Rotary,
+        DhParam(0, 90, 169.28, 0),
+        NoopInertialStateEstimator
     )
 )

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseFactoryTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseFactoryTest.kt
@@ -16,25 +16,15 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics.base
 
-import arrow.core.Either
 import arrow.core.right
 import com.beust.klaxon.Klaxon
-import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.SimpleKinematicBaseId
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseConfigurationData
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseScriptData
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopBodyController
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopJointAngleController
-import com.neuronrobotics.bowlerkernel.kinematics.limb.DefaultLimb
 import com.neuronrobotics.bowlerkernel.kinematics.limb.DefaultLimbFactory
-import com.neuronrobotics.bowlerkernel.kinematics.limb.limbid.SimpleLimbId
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DefaultLink
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DefaultLinkFactory
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DhParam
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.LinkType
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.LinkConfigurationData
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.LinkScriptData
-import com.neuronrobotics.bowlerkernel.kinematics.limb.model.DhParamData
-import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbConfigurationData
 import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbScriptData
 import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
 import com.neuronrobotics.bowlerkernel.kinematics.motion.LengthBasedReachabilityCalculator
@@ -47,12 +37,7 @@ import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.NoopLimbMotionPlan
 import com.neuronrobotics.bowlerkernel.scripting.factory.DefaultGitScriptFactory
 import com.neuronrobotics.bowlerkernel.scripting.parser.DefaultScriptLanguageParser
 import com.nhaarman.mockitokotlin2.mock
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
-import org.octogonapus.ktguava.collections.immutableListOf
-import org.octogonapus.ktguava.collections.immutableMapOf
 
 internal class DefaultKinematicBaseFactoryTest {
 
@@ -98,27 +83,35 @@ internal class DefaultKinematicBaseFactoryTest {
     )
 
     private val configData = KinematicBaseConfigurationData(
-        "base id",
+        "base id"
+    )
+
+    /*
+    ,
         listOf(
             LimbConfigurationData(
                 "limb 1 id",
                 listOf(
                     LinkConfigurationData(
                         LinkType.Rotary,
-                        DhParamData(10, 20, 30, 40)
+                        DhParamData(
+                            10,
+                            20,
+                            30,
+                            40
+                        )
                     )
                 )
             )
         ),
         listOf(FrameTransformation.fromTranslation(10, 20, 30))
-    )
+     */
 
     private val scriptData = KinematicBaseScriptData(
         ClassData.fromInstance(
             NoopBodyController,
             klaxon
-        ).right(),
-        listOf(limbScriptData)
+        ).right()
     )
 
     private val factory = DefaultKinematicBaseFactory(
@@ -139,50 +132,51 @@ internal class DefaultKinematicBaseFactoryTest {
 
     @Test
     fun `full base test`() {
-        val expected = DefaultKinematicBase(
-            SimpleKinematicBaseId("base id"),
-            immutableListOf(
-                DefaultLimb(
-                    SimpleLimbId("limb 1 id"),
-                    immutableListOf(
-                        DefaultLink(
-                            LinkType.Rotary,
-                            DhParam(10, 20, 30, 40),
-                            NoopInertialStateEstimator
-                        )
-                    ),
-                    NoopForwardKinematicsSolver,
-                    NoopInverseKinematicsSolver,
-                    LengthBasedReachabilityCalculator(),
-                    NoopLimbMotionPlanGenerator,
-                    NoopLimbMotionPlanFollower,
-                    immutableListOf(
-                        NoopJointAngleController
-                    ),
-                    NoopInertialStateEstimator
-                )
-            ),
-            immutableMapOf(
-                SimpleLimbId("limb 1 id") to
-                    FrameTransformation.fromTranslation(10, 20, 30)
-            ),
-            NoopBodyController
-        )
-
-        val actual = factory.create(configData, scriptData)
-
-        assertTrue(actual is Either.Right, "actual was $actual")
-        actual as Either.Right
-        val base = actual.b
-
-        assertAll(
-            { assertEquals(expected::class, base::class) },
-            { assertEquals(expected.id, base.id) },
-            { assertEquals(expected.limbs.size, base.limbs.size) },
-            { assertEquals(expected.limbs.first().id, base.limbs.first().id) },
-            { assertEquals(expected.limbs.first().links, base.limbs.first().links) },
-            { assertEquals(expected.limbBaseTransforms.entries, base.limbBaseTransforms.entries) },
-            { assertEquals(expected.bodyController::class, base.bodyController::class) }
-        )
+        TODO()
+        // val expected = DefaultKinematicBase(
+        //     SimpleKinematicBaseId("base id"),
+        //     immutableListOf(
+        //         DefaultLimb(
+        //             SimpleLimbId("limb 1 id"),
+        //             immutableListOf(
+        //                 DefaultLink(
+        //                     LinkType.Rotary,
+        //                     DhParam(10, 20, 30, 40),
+        //                     NoopInertialStateEstimator
+        //                 )
+        //             ),
+        //             NoopForwardKinematicsSolver,
+        //             NoopInverseKinematicsSolver,
+        //             LengthBasedReachabilityCalculator(),
+        //             NoopLimbMotionPlanGenerator,
+        //             NoopLimbMotionPlanFollower,
+        //             immutableListOf(
+        //                 NoopJointAngleController
+        //             ),
+        //             NoopInertialStateEstimator
+        //         )
+        //     ),
+        //     immutableMapOf(
+        //         SimpleLimbId("limb 1 id") to
+        //             FrameTransformation.fromTranslation(10, 20, 30)
+        //     ),
+        //     NoopBodyController
+        // )
+        //
+        // val actual = factory.create(configData, scriptData)
+        //
+        // assertTrue(actual is Either.Right, "actual was $actual")
+        // actual as Either.Right
+        // val base = actual.b
+        //
+        // assertAll(
+        //     { assertEquals(expected::class, base::class) },
+        //     { assertEquals(expected.id, base.id) },
+        //     { assertEquals(expected.limbs.size, base.limbs.size) },
+        //     { assertEquals(expected.limbs.first().id, base.limbs.first().id) },
+        //     { assertEquals(expected.limbs.first().links, base.limbs.first().links) },
+        //     { assertEquals(expected.limbBaseTransforms.entries, base.limbBaseTransforms.entries) },
+        //     { assertEquals(expected.bodyController::class, base.bodyController::class) }
+        // )
     }
 }

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseFactoryTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseFactoryTest.kt
@@ -17,6 +17,7 @@
 package com.neuronrobotics.bowlerkernel.kinematics.base
 
 import arrow.core.Either
+import arrow.core.right
 import com.beust.klaxon.Klaxon
 import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.SimpleKinematicBaseId
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseConfigurationData
@@ -41,7 +42,6 @@ import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopForwardKinematicsSo
 import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopInertialStateEstimator
 import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopInverseKinematicsSolver
 import com.neuronrobotics.bowlerkernel.kinematics.motion.model.ClassData
-import com.neuronrobotics.bowlerkernel.kinematics.motion.model.ControllerSpecification
 import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.NoopLimbMotionPlanFollower
 import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.NoopLimbMotionPlanGenerator
 import com.neuronrobotics.bowlerkernel.scripting.factory.DefaultGitScriptFactory
@@ -59,57 +59,41 @@ internal class DefaultKinematicBaseFactoryTest {
     private val klaxon = Klaxon().converter(FrameTransformation)
 
     private val linkScriptData = LinkScriptData(
-        ControllerSpecification.fromClassData(
-            ClassData.fromInstance(
-                NoopJointAngleController,
-                klaxon
-            )
-        ),
-        ControllerSpecification.fromClassData(
-            ClassData.fromInstance(
-                NoopInertialStateEstimator,
-                klaxon
-            )
-        )
+        ClassData.fromInstance(
+            NoopJointAngleController,
+            klaxon
+        ).right(),
+        ClassData.fromInstance(
+            NoopInertialStateEstimator,
+            klaxon
+        ).right()
     )
 
     private val limbScriptData = LimbScriptData(
-        ControllerSpecification.fromClassData(
-            ClassData.fromInstance(
-                NoopForwardKinematicsSolver,
-                klaxon
-            )
-        ),
-        ControllerSpecification.fromClassData(
-            ClassData.fromInstance(
-                NoopInverseKinematicsSolver,
-                klaxon
-            )
-        ),
-        ControllerSpecification.fromClassData(
-            ClassData.fromInstance(
-                LengthBasedReachabilityCalculator(),
-                klaxon
-            )
-        ),
-        ControllerSpecification.fromClassData(
-            ClassData.fromInstance(
-                NoopLimbMotionPlanGenerator,
-                klaxon
-            )
-        ),
-        ControllerSpecification.fromClassData(
-            ClassData.fromInstance(
-                NoopLimbMotionPlanFollower,
-                klaxon
-            )
-        ),
-        ControllerSpecification.fromClassData(
-            ClassData.fromInstance(
-                NoopInertialStateEstimator,
-                klaxon
-            )
-        ),
+        ClassData.fromInstance(
+            NoopForwardKinematicsSolver,
+            klaxon
+        ).right(),
+        ClassData.fromInstance(
+            NoopInverseKinematicsSolver,
+            klaxon
+        ).right(),
+        ClassData.fromInstance(
+            LengthBasedReachabilityCalculator(),
+            klaxon
+        ).right(),
+        ClassData.fromInstance(
+            NoopLimbMotionPlanGenerator,
+            klaxon
+        ).right(),
+        ClassData.fromInstance(
+            NoopLimbMotionPlanFollower,
+            klaxon
+        ).right(),
+        ClassData.fromInstance(
+            NoopInertialStateEstimator,
+            klaxon
+        ).right(),
         listOf(linkScriptData)
     )
 
@@ -126,18 +110,14 @@ internal class DefaultKinematicBaseFactoryTest {
                 )
             )
         ),
-        listOf(
-            FrameTransformation.fromTranslation(10, 20, 30)
-        )
+        listOf(FrameTransformation.fromTranslation(10, 20, 30))
     )
 
     private val scriptData = KinematicBaseScriptData(
-        ControllerSpecification.fromClassData(
-            ClassData.fromInstance(
-                NoopBodyController,
-                klaxon
-            )
-        ),
+        ClassData.fromInstance(
+            NoopBodyController,
+            klaxon
+        ).right(),
         listOf(limbScriptData)
     )
 

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseFactoryTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseFactoryTest.kt
@@ -16,15 +16,25 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics.base
 
+import arrow.core.Either
 import arrow.core.right
 import com.beust.klaxon.Klaxon
+import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.SimpleKinematicBaseId
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseConfigurationData
 import com.neuronrobotics.bowlerkernel.kinematics.base.model.KinematicBaseScriptData
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopBodyController
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopJointAngleController
+import com.neuronrobotics.bowlerkernel.kinematics.limb.DefaultLimb
 import com.neuronrobotics.bowlerkernel.kinematics.limb.DefaultLimbFactory
+import com.neuronrobotics.bowlerkernel.kinematics.limb.limbid.SimpleLimbId
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DefaultLink
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DefaultLinkFactory
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DhParam
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.LinkType
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.DhParamData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.LinkConfigurationData
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.LinkScriptData
+import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbConfigurationData
 import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbScriptData
 import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
 import com.neuronrobotics.bowlerkernel.kinematics.motion.LengthBasedReachabilityCalculator
@@ -37,81 +47,50 @@ import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.NoopLimbMotionPlan
 import com.neuronrobotics.bowlerkernel.scripting.factory.DefaultGitScriptFactory
 import com.neuronrobotics.bowlerkernel.scripting.parser.DefaultScriptLanguageParser
 import com.nhaarman.mockitokotlin2.mock
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.octogonapus.ktguava.collections.immutableListOf
+import org.octogonapus.ktguava.collections.immutableMapOf
+import org.octogonapus.ktguava.collections.immutableSetOf
 
 internal class DefaultKinematicBaseFactoryTest {
 
     private val klaxon = Klaxon().converter(FrameTransformation)
 
     private val linkScriptData = LinkScriptData(
-        ClassData.fromInstance(
-            NoopJointAngleController,
-            klaxon
-        ).right(),
-        ClassData.fromInstance(
-            NoopInertialStateEstimator,
-            klaxon
-        ).right()
+        ClassData.fromInstance(NoopJointAngleController, klaxon).right(),
+        ClassData.fromInstance(NoopInertialStateEstimator, klaxon).right()
     )
 
+    private val limbConfigurationData = LimbConfigurationData(
+        "limb 1 id",
+        listOf(
+            LinkConfigurationData(
+                LinkType.Rotary,
+                DhParamData(10, 20, 30, 40)
+            )
+        )
+    )
+
+    private val limbBaseTransform =
+        SimpleLimbId("limb 1 id") to FrameTransformation.fromTranslation(10, 20, 30)
+
     private val limbScriptData = LimbScriptData(
-        ClassData.fromInstance(
-            NoopForwardKinematicsSolver,
-            klaxon
-        ).right(),
-        ClassData.fromInstance(
-            NoopInverseKinematicsSolver,
-            klaxon
-        ).right(),
-        ClassData.fromInstance(
-            LengthBasedReachabilityCalculator(),
-            klaxon
-        ).right(),
-        ClassData.fromInstance(
-            NoopLimbMotionPlanGenerator,
-            klaxon
-        ).right(),
-        ClassData.fromInstance(
-            NoopLimbMotionPlanFollower,
-            klaxon
-        ).right(),
-        ClassData.fromInstance(
-            NoopInertialStateEstimator,
-            klaxon
-        ).right(),
+        ClassData.fromInstance(NoopForwardKinematicsSolver, klaxon).right(),
+        ClassData.fromInstance(NoopInverseKinematicsSolver, klaxon).right(),
+        ClassData.fromInstance(LengthBasedReachabilityCalculator(), klaxon).right(),
+        ClassData.fromInstance(NoopLimbMotionPlanGenerator, klaxon).right(),
+        ClassData.fromInstance(NoopLimbMotionPlanFollower, klaxon).right(),
+        ClassData.fromInstance(NoopInertialStateEstimator, klaxon).right(),
         listOf(linkScriptData)
     )
 
-    private val configData = KinematicBaseConfigurationData(
-        "base id"
-    )
-
-    /*
-    ,
-        listOf(
-            LimbConfigurationData(
-                "limb 1 id",
-                listOf(
-                    LinkConfigurationData(
-                        LinkType.Rotary,
-                        DhParamData(
-                            10,
-                            20,
-                            30,
-                            40
-                        )
-                    )
-                )
-            )
-        ),
-        listOf(FrameTransformation.fromTranslation(10, 20, 30))
-     */
+    private val configData = KinematicBaseConfigurationData("base id")
 
     private val scriptData = KinematicBaseScriptData(
-        ClassData.fromInstance(
-            NoopBodyController,
-            klaxon
-        ).right()
+        ClassData.fromInstance(NoopBodyController, klaxon).right()
     )
 
     private val factory = DefaultKinematicBaseFactory(
@@ -121,10 +100,7 @@ internal class DefaultKinematicBaseFactoryTest {
         ),
         DefaultLimbFactory(
             mock {},
-            DefaultLinkFactory(
-                mock {},
-                klaxon
-            ),
+            DefaultLinkFactory(mock {}, klaxon),
             klaxon
         ),
         klaxon
@@ -132,51 +108,53 @@ internal class DefaultKinematicBaseFactoryTest {
 
     @Test
     fun `full base test`() {
-        TODO()
-        // val expected = DefaultKinematicBase(
-        //     SimpleKinematicBaseId("base id"),
-        //     immutableListOf(
-        //         DefaultLimb(
-        //             SimpleLimbId("limb 1 id"),
-        //             immutableListOf(
-        //                 DefaultLink(
-        //                     LinkType.Rotary,
-        //                     DhParam(10, 20, 30, 40),
-        //                     NoopInertialStateEstimator
-        //                 )
-        //             ),
-        //             NoopForwardKinematicsSolver,
-        //             NoopInverseKinematicsSolver,
-        //             LengthBasedReachabilityCalculator(),
-        //             NoopLimbMotionPlanGenerator,
-        //             NoopLimbMotionPlanFollower,
-        //             immutableListOf(
-        //                 NoopJointAngleController
-        //             ),
-        //             NoopInertialStateEstimator
-        //         )
-        //     ),
-        //     immutableMapOf(
-        //         SimpleLimbId("limb 1 id") to
-        //             FrameTransformation.fromTranslation(10, 20, 30)
-        //     ),
-        //     NoopBodyController
-        // )
-        //
-        // val actual = factory.create(configData, scriptData)
-        //
-        // assertTrue(actual is Either.Right, "actual was $actual")
-        // actual as Either.Right
-        // val base = actual.b
-        //
-        // assertAll(
-        //     { assertEquals(expected::class, base::class) },
-        //     { assertEquals(expected.id, base.id) },
-        //     { assertEquals(expected.limbs.size, base.limbs.size) },
-        //     { assertEquals(expected.limbs.first().id, base.limbs.first().id) },
-        //     { assertEquals(expected.limbs.first().links, base.limbs.first().links) },
-        //     { assertEquals(expected.limbBaseTransforms.entries, base.limbBaseTransforms.entries) },
-        //     { assertEquals(expected.bodyController::class, base.bodyController::class) }
-        // )
+        val expected = DefaultKinematicBase(
+            SimpleKinematicBaseId("base id"),
+            NoopBodyController,
+            immutableSetOf(
+                DefaultLimb(
+                    SimpleLimbId("limb 1 id"),
+                    immutableListOf(
+                        DefaultLink(
+                            LinkType.Rotary,
+                            DhParam(10, 20, 30, 40),
+                            NoopInertialStateEstimator
+                        )
+                    ),
+                    NoopForwardKinematicsSolver,
+                    NoopInverseKinematicsSolver,
+                    LengthBasedReachabilityCalculator(),
+                    NoopLimbMotionPlanGenerator,
+                    NoopLimbMotionPlanFollower,
+                    immutableListOf(NoopJointAngleController),
+                    NoopInertialStateEstimator
+                )
+            ),
+            immutableMapOf(
+                SimpleLimbId("limb 1 id") to
+                    FrameTransformation.fromTranslation(10, 20, 30)
+            )
+        )
+
+        val actual = factory.create(
+            configData,
+            scriptData,
+            listOf(limbConfigurationData to limbScriptData),
+            listOf(limbBaseTransform).toMap()
+        )
+
+        assertTrue(actual is Either.Right, "actual was $actual")
+        actual as Either.Right
+        val base = actual.b as DefaultKinematicBase
+
+        assertAll(
+            { assertEquals(expected::class, base::class) },
+            { assertEquals(expected.id, base.id) },
+            { assertEquals(expected.limbs.size, base.limbs.size) },
+            { assertEquals(expected.limbs.first().id, base.limbs.first().id) },
+            { assertEquals(expected.limbs.first().links, base.limbs.first().links) },
+            { assertEquals(expected.limbBaseTransforms.entries, base.limbBaseTransforms.entries) },
+            { assertEquals(expected.bodyController::class, base.bodyController::class) }
+        )
     }
 }

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseTest.kt
@@ -16,56 +16,22 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics.base
 
-import com.google.common.collect.ImmutableList
-import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.SimpleKinematicBaseId
-import com.neuronrobotics.bowlerkernel.kinematics.closedloop.BodyController
-import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopBodyController
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopJointAngleController
 import com.neuronrobotics.bowlerkernel.kinematics.limb.DefaultLimb
 import com.neuronrobotics.bowlerkernel.kinematics.limb.limbid.SimpleLimbId
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DefaultLink
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DhParam
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.Link
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.LinkType
-import com.neuronrobotics.bowlerkernel.kinematics.motion.BasicMotionConstraints
-import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
 import com.neuronrobotics.bowlerkernel.kinematics.motion.LengthBasedReachabilityCalculator
 import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopForwardKinematicsSolver
 import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopInertialStateEstimator
 import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopInverseKinematicsSolver
 import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.NoopLimbMotionPlanFollower
 import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.NoopLimbMotionPlanGenerator
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
+import com.neuronrobotics.bowlerkernel.kinematics.seaArmLinks
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
-import org.octogonapus.ktguava.collections.immutableListOf
-import org.octogonapus.ktguava.collections.immutableMapOf
 import org.octogonapus.ktguava.collections.toImmutableList
 
 internal class DefaultKinematicBaseTest {
 
     private val tolerance = 1e-10
-
-    private val seaArmLinks: ImmutableList<Link> = immutableListOf(
-        DefaultLink(
-            LinkType.Rotary,
-            DhParam(135, 0, 0, -90),
-            NoopInertialStateEstimator
-        ),
-        DefaultLink(
-            LinkType.Rotary,
-            DhParam(0, 0, 175, 0),
-            NoopInertialStateEstimator
-        ),
-        DefaultLink(
-            LinkType.Rotary,
-            DhParam(0, 90, 169.28, 0),
-            NoopInertialStateEstimator
-        )
-    )
 
     private val limb = DefaultLimb(
         SimpleLimbId("limb"),
@@ -81,130 +47,133 @@ internal class DefaultKinematicBaseTest {
         NoopInertialStateEstimator
     )
 
-    private fun makeBase(limbRootTransform: FrameTransformation) = DefaultKinematicBase(
-        SimpleKinematicBaseId("base"),
-        immutableListOf(limb),
-        immutableMapOf(limb.id to limbRootTransform),
-        NoopBodyController
-    )
+    // private fun makeBase(limbRootTransform: FrameTransformation) = DefaultKinematicBase(
+    //     SimpleKinematicBaseId("base"),
+    //     immutableListOf(limb),
+    //     immutableMapOf(limb.id to limbRootTransform),
+    //     NoopBodyController
+    // )
 
     @Test
     fun `test setting limb tip transform`() {
-        val base = makeBase(FrameTransformation.fromTranslation(10, 0, -10))
-
-        base.setCurrentWorldSpaceTransform(
-            FrameTransformation.fromTranslation(10, 10, 0)
-        )
-
-        val desiredTipTransform = FrameTransformation.fromTranslation(25, 0, -15)
-        base.setDesiredLimbTipTransform(
-            limb.id,
-            desiredTipTransform,
-            BasicMotionConstraints(1, 0, 0, 0)
-        )
-
-        assertAll(
-            {
-                val expected = base.getDesiredLimbTipTransform(limb.id)
-                assertTrue(
-                    expected.approxEquals(desiredTipTransform, tolerance),
-                    """
-                    |Expected:
-                    |$expected
-                    |Actual:
-                    |$desiredTipTransform
-                    """.trimMargin()
-                )
-            },
-            {
-                val expected = FrameTransformation.fromTranslation(
-                    x = 25 - 10 - 10,
-                    y = 0 - 10,
-                    z = -15 - -10
-                )
-                val actual = limb.getDesiredTaskSpaceTransform()
-                assertTrue(
-                    expected.approxEquals(actual, tolerance),
-                    """
-                    |Expected:
-                    |$expected
-                    |Actual:
-                    |$actual
-                    """.trimMargin()
-                )
-            }
-        )
+        TODO()
+        // val base = makeBase(FrameTransformation.fromTranslation(10, 0, -10))
+        //
+        // base.setCurrentWorldSpaceTransform(
+        //     FrameTransformation.fromTranslation(10, 10, 0)
+        // )
+        //
+        // val desiredTipTransform = FrameTransformation.fromTranslation(25, 0, -15)
+        // base.setDesiredLimbTipTransform(
+        //     limb.id,
+        //     desiredTipTransform,
+        //     BasicMotionConstraints(1, 0, 0, 0)
+        // )
+        //
+        // assertAll(
+        //     {
+        //         val expected = base.getDesiredLimbTipTransform(limb.id)
+        //         assertTrue(
+        //             expected.approxEquals(desiredTipTransform, tolerance),
+        //             """
+        //             |Expected:
+        //             |$expected
+        //             |Actual:
+        //             |$desiredTipTransform
+        //             """.trimMargin()
+        //         )
+        //     },
+        //     {
+        //         val expected = FrameTransformation.fromTranslation(
+        //             x = 25 - 10 - 10,
+        //             y = 0 - 10,
+        //             z = -15 - -10
+        //         )
+        //         val actual = limb.getDesiredTaskSpaceTransform()
+        //         assertTrue(
+        //             expected.approxEquals(actual, tolerance),
+        //             """
+        //             |Expected:
+        //             |$expected
+        //             |Actual:
+        //             |$actual
+        //             """.trimMargin()
+        //         )
+        //     }
+        // )
     }
 
     @Test
     fun `test setting limb tip transform with rotation on base world transform`() {
-        val base = makeBase(FrameTransformation.fromTranslation(10, 0, -10))
-
-        base.setCurrentWorldSpaceTransform(
-            FrameTransformation.fromTranslation(10, 0, 0) *
-                FrameTransformation.fromRotation(0, 90, 0)
-        )
-
-        val desiredTipTransform = FrameTransformation.fromTranslation(25, 0, -15)
-        base.setDesiredLimbTipTransform(
-            limb.id,
-            desiredTipTransform,
-            BasicMotionConstraints(1, 0, 0, 0)
-        )
-
-        assertAll(
-            {
-                val expected = base.getDesiredLimbTipTransform(limb.id)
-                assertTrue(
-                    expected.approxEquals(desiredTipTransform, tolerance),
-                    """
-                    |Expected:
-                    |$expected
-                    |Actual:
-                    |$desiredTipTransform
-                    """.trimMargin()
-                )
-            },
-            {
-                val expected = FrameTransformation.fromTranslation(
-                    x = 25 - 10,
-                    y = 0,
-                    z = -15 - 10 - 10
-                ) * FrameTransformation.fromRotation(0, -90, 0)
-                val actual = limb.getDesiredTaskSpaceTransform()
-                assertTrue(
-                    expected.approxEquals(actual, tolerance),
-                    """
-                    |Expected:
-                    |$expected
-                    |Actual:
-                    |$actual
-                    """.trimMargin()
-                )
-            }
-        )
+        TODO()
+        // val base = makeBase(FrameTransformation.fromTranslation(10, 0, -10))
+        //
+        // base.setCurrentWorldSpaceTransform(
+        //     FrameTransformation.fromTranslation(10, 0, 0) *
+        //         FrameTransformation.fromRotation(0, 90, 0)
+        // )
+        //
+        // val desiredTipTransform = FrameTransformation.fromTranslation(25, 0, -15)
+        // base.setDesiredLimbTipTransform(
+        //     limb.id,
+        //     desiredTipTransform,
+        //     BasicMotionConstraints(1, 0, 0, 0)
+        // )
+        //
+        // assertAll(
+        //     {
+        //         val expected = base.getDesiredLimbTipTransform(limb.id)
+        //         assertTrue(
+        //             expected.approxEquals(desiredTipTransform, tolerance),
+        //             """
+        //             |Expected:
+        //             |$expected
+        //             |Actual:
+        //             |$desiredTipTransform
+        //             """.trimMargin()
+        //         )
+        //     },
+        //     {
+        //         val expected = FrameTransformation.fromTranslation(
+        //             x = 25 - 10,
+        //             y = 0,
+        //             z = -15 - 10 - 10
+        //         ) * FrameTransformation.fromRotation(0, -90, 0)
+        //         val actual = limb.getDesiredTaskSpaceTransform()
+        //         assertTrue(
+        //             expected.approxEquals(actual, tolerance),
+        //             """
+        //             |Expected:
+        //             |$expected
+        //             |Actual:
+        //             |$actual
+        //             """.trimMargin()
+        //         )
+        //     }
+        // )
     }
 
     @Test
     fun `test get current world space transform`() {
-        val mockBodyController = mock<BodyController> {
-            on { getDeltaSinceLastDesiredTransform() } doReturn
-                FrameTransformation.fromTranslation(10, 0, 0)
-        }
-
-        val base = DefaultKinematicBase(
-            SimpleKinematicBaseId("base"),
-            immutableListOf(limb),
-            immutableMapOf(limb.id to FrameTransformation.identity),
-            mockBodyController
-        )
-
-        base.setCurrentWorldSpaceTransform(FrameTransformation.fromTranslation(10, 0, 0))
-
-        assertEquals(
-            // body controller delta should be added
-            FrameTransformation.fromTranslation(20, 0, 0),
-            base.getCurrentWorldSpaceTransformWithDelta()
-        )
+        TODO()
+        // val mockBodyController = mock<BodyController> {
+        //     on { getDeltaSinceLastDesiredTransform() } doReturn
+        //         FrameTransformation.fromTranslation(10, 0, 0)
+        // }
+        //
+        // val base = DefaultKinematicBase(
+        //     SimpleKinematicBaseId("base"),
+        //     immutableListOf(limb),
+        //     immutableMapOf(limb.id to FrameTransformation.identity),
+        //     mockBodyController
+        // )
+        //
+        // base.setCurrentWorldSpaceTransform(FrameTransformation.fromTranslation(10, 0, 0))
+        //
+        // assertEquals(
+        //     // body controller delta should be added
+        //     FrameTransformation.fromTranslation(20, 0, 0),
+        //     base.getCurrentWorldSpaceTransformWithDelta()
+        // )
     }
 }

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/DefaultKinematicBaseTest.kt
@@ -16,9 +16,14 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics.base
 
+import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.SimpleKinematicBaseId
+import com.neuronrobotics.bowlerkernel.kinematics.closedloop.BodyController
+import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopBodyController
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopJointAngleController
 import com.neuronrobotics.bowlerkernel.kinematics.limb.DefaultLimb
 import com.neuronrobotics.bowlerkernel.kinematics.limb.limbid.SimpleLimbId
+import com.neuronrobotics.bowlerkernel.kinematics.motion.BasicMotionConstraints
+import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
 import com.neuronrobotics.bowlerkernel.kinematics.motion.LengthBasedReachabilityCalculator
 import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopForwardKinematicsSolver
 import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopInertialStateEstimator
@@ -26,7 +31,14 @@ import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopInverseKinematicsSo
 import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.NoopLimbMotionPlanFollower
 import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.NoopLimbMotionPlanGenerator
 import com.neuronrobotics.bowlerkernel.kinematics.seaArmLinks
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.octogonapus.ktguava.collections.immutableMapOf
+import org.octogonapus.ktguava.collections.immutableSetOf
 import org.octogonapus.ktguava.collections.toImmutableList
 
 internal class DefaultKinematicBaseTest {
@@ -47,133 +59,130 @@ internal class DefaultKinematicBaseTest {
         NoopInertialStateEstimator
     )
 
-    // private fun makeBase(limbRootTransform: FrameTransformation) = DefaultKinematicBase(
-    //     SimpleKinematicBaseId("base"),
-    //     immutableListOf(limb),
-    //     immutableMapOf(limb.id to limbRootTransform),
-    //     NoopBodyController
-    // )
+    private fun makeBase(limbRootTransform: FrameTransformation) = DefaultKinematicBase(
+        SimpleKinematicBaseId("base"),
+        NoopBodyController,
+        immutableSetOf(limb),
+        immutableMapOf(limb.id to limbRootTransform)
+    )
 
     @Test
     fun `test setting limb tip transform`() {
-        TODO()
-        // val base = makeBase(FrameTransformation.fromTranslation(10, 0, -10))
-        //
-        // base.setCurrentWorldSpaceTransform(
-        //     FrameTransformation.fromTranslation(10, 10, 0)
-        // )
-        //
-        // val desiredTipTransform = FrameTransformation.fromTranslation(25, 0, -15)
-        // base.setDesiredLimbTipTransform(
-        //     limb.id,
-        //     desiredTipTransform,
-        //     BasicMotionConstraints(1, 0, 0, 0)
-        // )
-        //
-        // assertAll(
-        //     {
-        //         val expected = base.getDesiredLimbTipTransform(limb.id)
-        //         assertTrue(
-        //             expected.approxEquals(desiredTipTransform, tolerance),
-        //             """
-        //             |Expected:
-        //             |$expected
-        //             |Actual:
-        //             |$desiredTipTransform
-        //             """.trimMargin()
-        //         )
-        //     },
-        //     {
-        //         val expected = FrameTransformation.fromTranslation(
-        //             x = 25 - 10 - 10,
-        //             y = 0 - 10,
-        //             z = -15 - -10
-        //         )
-        //         val actual = limb.getDesiredTaskSpaceTransform()
-        //         assertTrue(
-        //             expected.approxEquals(actual, tolerance),
-        //             """
-        //             |Expected:
-        //             |$expected
-        //             |Actual:
-        //             |$actual
-        //             """.trimMargin()
-        //         )
-        //     }
-        // )
+        val base = makeBase(FrameTransformation.fromTranslation(10, 0, -10))
+
+        base.setCurrentWorldSpaceTransform(
+            FrameTransformation.fromTranslation(10, 10, 0)
+        )
+
+        val desiredTipTransform = FrameTransformation.fromTranslation(25, 0, -15)
+        base.setDesiredLimbTipTransform(
+            limb.id,
+            desiredTipTransform,
+            BasicMotionConstraints(1, 0, 0, 0)
+        )
+
+        assertAll(
+            {
+                val expected = base.getDesiredLimbTipTransform(limb.id)
+                assertTrue(
+                    expected.approxEquals(desiredTipTransform, tolerance),
+                    """
+                    |Expected:
+                    |$expected
+                    |Actual:
+                    |$desiredTipTransform
+                    """.trimMargin()
+                )
+            },
+            {
+                val expected = FrameTransformation.fromTranslation(
+                    x = 25 - 10 - 10,
+                    y = 0 - 10,
+                    z = -15 - -10
+                )
+                val actual = limb.getDesiredTaskSpaceTransform()
+                assertTrue(
+                    expected.approxEquals(actual, tolerance),
+                    """
+                    |Expected:
+                    |$expected
+                    |Actual:
+                    |$actual
+                    """.trimMargin()
+                )
+            }
+        )
     }
 
     @Test
     fun `test setting limb tip transform with rotation on base world transform`() {
-        TODO()
-        // val base = makeBase(FrameTransformation.fromTranslation(10, 0, -10))
-        //
-        // base.setCurrentWorldSpaceTransform(
-        //     FrameTransformation.fromTranslation(10, 0, 0) *
-        //         FrameTransformation.fromRotation(0, 90, 0)
-        // )
-        //
-        // val desiredTipTransform = FrameTransformation.fromTranslation(25, 0, -15)
-        // base.setDesiredLimbTipTransform(
-        //     limb.id,
-        //     desiredTipTransform,
-        //     BasicMotionConstraints(1, 0, 0, 0)
-        // )
-        //
-        // assertAll(
-        //     {
-        //         val expected = base.getDesiredLimbTipTransform(limb.id)
-        //         assertTrue(
-        //             expected.approxEquals(desiredTipTransform, tolerance),
-        //             """
-        //             |Expected:
-        //             |$expected
-        //             |Actual:
-        //             |$desiredTipTransform
-        //             """.trimMargin()
-        //         )
-        //     },
-        //     {
-        //         val expected = FrameTransformation.fromTranslation(
-        //             x = 25 - 10,
-        //             y = 0,
-        //             z = -15 - 10 - 10
-        //         ) * FrameTransformation.fromRotation(0, -90, 0)
-        //         val actual = limb.getDesiredTaskSpaceTransform()
-        //         assertTrue(
-        //             expected.approxEquals(actual, tolerance),
-        //             """
-        //             |Expected:
-        //             |$expected
-        //             |Actual:
-        //             |$actual
-        //             """.trimMargin()
-        //         )
-        //     }
-        // )
+        val base = makeBase(FrameTransformation.fromTranslation(10, 0, -10))
+
+        base.setCurrentWorldSpaceTransform(
+            FrameTransformation.fromTranslation(10, 0, 0) *
+                FrameTransformation.fromRotation(0, 90, 0)
+        )
+
+        val desiredTipTransform = FrameTransformation.fromTranslation(25, 0, -15)
+        base.setDesiredLimbTipTransform(
+            limb.id,
+            desiredTipTransform,
+            BasicMotionConstraints(1, 0, 0, 0)
+        )
+
+        assertAll(
+            {
+                val expected = base.getDesiredLimbTipTransform(limb.id)
+                assertTrue(
+                    expected.approxEquals(desiredTipTransform, tolerance),
+                    """
+                    |Expected:
+                    |$expected
+                    |Actual:
+                    |$desiredTipTransform
+                    """.trimMargin()
+                )
+            },
+            {
+                val expected = FrameTransformation.fromTranslation(
+                    x = 25 - 10,
+                    y = 0,
+                    z = -15 - 10 - 10
+                ) * FrameTransformation.fromRotation(0, -90, 0)
+                val actual = limb.getDesiredTaskSpaceTransform()
+                assertTrue(
+                    expected.approxEquals(actual, tolerance),
+                    """
+                    |Expected:
+                    |$expected
+                    |Actual:
+                    |$actual
+                    """.trimMargin()
+                )
+            }
+        )
     }
 
     @Test
     fun `test get current world space transform`() {
-        TODO()
-        // val mockBodyController = mock<BodyController> {
-        //     on { getDeltaSinceLastDesiredTransform() } doReturn
-        //         FrameTransformation.fromTranslation(10, 0, 0)
-        // }
-        //
-        // val base = DefaultKinematicBase(
-        //     SimpleKinematicBaseId("base"),
-        //     immutableListOf(limb),
-        //     immutableMapOf(limb.id to FrameTransformation.identity),
-        //     mockBodyController
-        // )
-        //
-        // base.setCurrentWorldSpaceTransform(FrameTransformation.fromTranslation(10, 0, 0))
-        //
-        // assertEquals(
-        //     // body controller delta should be added
-        //     FrameTransformation.fromTranslation(20, 0, 0),
-        //     base.getCurrentWorldSpaceTransformWithDelta()
-        // )
+        val mockBodyController = mock<BodyController> {
+            on { getDeltaSinceLastDesiredTransform() } doReturn
+                FrameTransformation.fromTranslation(10, 0, 0)
+        }
+
+        val base = DefaultKinematicBase(
+            SimpleKinematicBaseId("base"),
+            mockBodyController,
+            immutableSetOf(limb),
+            immutableMapOf(limb.id to FrameTransformation.identity)
+        )
+
+        base.setCurrentWorldSpaceTransform(FrameTransformation.fromTranslation(10, 0, 0))
+
+        assertEquals(
+            // body controller delta should be added
+            FrameTransformation.fromTranslation(20, 0, 0),
+            base.getCurrentWorldSpaceTransformWithDelta()
+        )
     }
 }

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/model/KinematicBaseConfigurationDataTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/model/KinematicBaseConfigurationDataTest.kt
@@ -18,11 +18,8 @@ package com.neuronrobotics.bowlerkernel.kinematics.base.model
 
 import arrow.core.right
 import com.neuronrobotics.bowlerkernel.kinematics.kinematicBaseConfigurationData
-import com.neuronrobotics.bowlerkernel.kinematics.limbConfigurationData
-import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 internal class KinematicBaseConfigurationDataTest {
 
@@ -35,16 +32,5 @@ internal class KinematicBaseConfigurationDataTest {
         }.decode(KinematicBaseConfigurationData.decoder())
 
         assertEquals(expected.right(), decoded)
-    }
-
-    @Test
-    fun `test constructor with unequal number of limb and transforms`() {
-        assertThrows<IllegalArgumentException> {
-            KinematicBaseConfigurationData(
-                "A",
-                listOf(limbConfigurationData(), limbConfigurationData()),
-                listOf(FrameTransformation.identity)
-            )
-        }
     }
 }

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/model/KinematicBaseConfigurationDataTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/base/model/KinematicBaseConfigurationDataTest.kt
@@ -16,37 +16,35 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics.base.model
 
-import com.beust.klaxon.Klaxon
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.LinkType
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.model.LinkConfigurationData
-import com.neuronrobotics.bowlerkernel.kinematics.limb.model.DhParamData
-import com.neuronrobotics.bowlerkernel.kinematics.limb.model.LimbConfigurationData
+import arrow.core.right
+import com.neuronrobotics.bowlerkernel.kinematics.kinematicBaseConfigurationData
+import com.neuronrobotics.bowlerkernel.kinematics.limbConfigurationData
 import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
-import com.neuronrobotics.bowlerkernel.kinematics.testJsonConversion
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 internal class KinematicBaseConfigurationDataTest {
 
     @Test
     fun `test json`() {
-        Klaxon().converter(FrameTransformation).testJsonConversion(
+        val expected = kinematicBaseConfigurationData()
+
+        val decoded = with(KinematicBaseConfigurationData.encoder()) {
+            expected.encode()
+        }.decode(KinematicBaseConfigurationData.decoder())
+
+        assertEquals(expected.right(), decoded)
+    }
+
+    @Test
+    fun `test constructor with unequal number of limb and transforms`() {
+        assertThrows<IllegalArgumentException> {
             KinematicBaseConfigurationData(
-                "base id",
-                listOf(
-                    LimbConfigurationData(
-                        "limb 1 id",
-                        listOf(
-                            LinkConfigurationData(
-                                LinkType.Rotary,
-                                DhParamData(10, 20, 30, 40)
-                            )
-                        )
-                    )
-                ),
-                listOf(
-                    FrameTransformation.fromTranslation(10, 20, 30)
-                )
+                "A",
+                listOf(limbConfigurationData(), limbConfigurationData()),
+                listOf(FrameTransformation.identity)
             )
-        )
+        }
     }
 }

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/graph/KinematicGraphTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/graph/KinematicGraphTest.kt
@@ -19,7 +19,6 @@ package com.neuronrobotics.bowlerkernel.kinematics.graph
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
-import com.google.common.graph.ImmutableNetwork
 import com.neuronrobotics.bowlerkernel.kinematics.base.DefaultKinematicBase
 import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.SimpleKinematicBaseId
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopBodyController
@@ -41,6 +40,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.octogonapus.ktguava.collections.toImmutableList
+import org.octogonapus.ktguava.collections.toImmutableNetwork
 
 @Suppress("UnstableApiUsage")
 internal class KinematicGraphTest {
@@ -66,7 +66,7 @@ internal class KinematicGraphTest {
             FrameTransformation.fromTranslation(-10, 0, -10)
         )
 
-        val kinematicGraph = ImmutableNetwork.copyOf(mutableKinematicGraph)
+        val kinematicGraph = mutableKinematicGraph.toImmutableNetwork()
 
         val baseA = DefaultKinematicBase.create(
             kinematicGraph,

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/graph/KinematicGraphTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/graph/KinematicGraphTest.kt
@@ -1,0 +1,115 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.kinematics.graph
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import com.google.common.graph.ImmutableNetwork
+import com.google.common.graph.NetworkBuilder
+import com.neuronrobotics.bowlerkernel.kinematics.base.DefaultKinematicBase
+import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.SimpleKinematicBaseId
+import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopBodyController
+import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopJointAngleController
+import com.neuronrobotics.bowlerkernel.kinematics.limb.DefaultLimb
+import com.neuronrobotics.bowlerkernel.kinematics.limb.DefaultLimbFactory
+import com.neuronrobotics.bowlerkernel.kinematics.limb.limbid.SimpleLimbId
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DefaultLinkFactory
+import com.neuronrobotics.bowlerkernel.kinematics.motion.FrameTransformation
+import com.neuronrobotics.bowlerkernel.kinematics.motion.LengthBasedReachabilityCalculator
+import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopForwardKinematicsSolver
+import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopInertialStateEstimator
+import com.neuronrobotics.bowlerkernel.kinematics.motion.NoopInverseKinematicsSolver
+import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.NoopLimbMotionPlanFollower
+import com.neuronrobotics.bowlerkernel.kinematics.motion.plan.NoopLimbMotionPlanGenerator
+import com.neuronrobotics.bowlerkernel.kinematics.seaArmLinks
+import com.nhaarman.mockitokotlin2.mock
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.octogonapus.ktguava.collections.toImmutableList
+
+@Suppress("UnstableApiUsage")
+internal class KinematicGraphTest {
+
+    @Test
+    fun `test json conversion`() {
+        val mutableKinematicGraph: MutableKinematicGraph = NetworkBuilder.directed()
+            .allowsParallelEdges(false)
+            .allowsSelfLoops(false)
+            .build()
+
+        val baseNodeA = BaseNode(SimpleKinematicBaseId("BaseA")).left()
+
+        val limbA = makeLimb("LimbA")
+        val limbB = makeLimb("LimbB")
+
+        mutableKinematicGraph.addEdge(
+            baseNodeA,
+            limbA,
+            FrameTransformation.fromTranslation(10, 0, -10)
+        )
+
+        mutableKinematicGraph.addEdge(
+            baseNodeA,
+            limbB,
+            FrameTransformation.fromTranslation(-10, 0, -10)
+        )
+
+        val kinematicGraph = ImmutableNetwork.copyOf(mutableKinematicGraph)
+
+        val baseA = DefaultKinematicBase(
+            SimpleKinematicBaseId("BaseA"),
+            kinematicGraph,
+            NoopBodyController
+        )
+
+        val kinematicGraphData = kinematicGraph.convertToKinematicGraphData(setOf(baseA))
+
+        val graphJson = KinematicGraphData.encoder().run { kinematicGraphData.encode() }
+
+        val decodedGraph = graphJson.decode(KinematicGraphData.decoder())
+        assertTrue(decodedGraph.isRight())
+        decodedGraph as Either.Right
+
+        val convertedKinematicGraph = decodedGraph.b.convertToKinematicGraph(
+            DefaultLimbFactory(
+                mock {},
+                DefaultLinkFactory(mock {})
+            )
+        )
+
+        assertTrue(convertedKinematicGraph is Either.Right)
+        convertedKinematicGraph as Either.Right
+
+        assertEquals(kinematicGraph.fullEdges(), convertedKinematicGraph.b.fullEdges())
+    }
+
+    private fun makeLimb(name: String) = DefaultLimb(
+        SimpleLimbId(name),
+        seaArmLinks,
+        NoopForwardKinematicsSolver,
+        NoopInverseKinematicsSolver,
+        LengthBasedReachabilityCalculator(),
+        NoopLimbMotionPlanGenerator,
+        NoopLimbMotionPlanFollower,
+        seaArmLinks.map {
+            NoopJointAngleController
+        }.toImmutableList(),
+        NoopInertialStateEstimator
+    ).right()
+}

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/graph/KinematicGraphTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/graph/KinematicGraphTest.kt
@@ -20,7 +20,6 @@ import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
 import com.google.common.graph.ImmutableNetwork
-import com.google.common.graph.NetworkBuilder
 import com.neuronrobotics.bowlerkernel.kinematics.base.DefaultKinematicBase
 import com.neuronrobotics.bowlerkernel.kinematics.base.baseid.SimpleKinematicBaseId
 import com.neuronrobotics.bowlerkernel.kinematics.closedloop.NoopBodyController
@@ -48,10 +47,7 @@ internal class KinematicGraphTest {
 
     @Test
     fun `test json conversion`() {
-        val mutableKinematicGraph: MutableKinematicGraph = NetworkBuilder.directed()
-            .allowsParallelEdges(false)
-            .allowsSelfLoops(false)
-            .build()
+        val mutableKinematicGraph = buildMutableKinematicGraph()
 
         val baseNodeA = BaseNode(SimpleKinematicBaseId("BaseA")).left()
 
@@ -72,9 +68,9 @@ internal class KinematicGraphTest {
 
         val kinematicGraph = ImmutableNetwork.copyOf(mutableKinematicGraph)
 
-        val baseA = DefaultKinematicBase(
-            SimpleKinematicBaseId("BaseA"),
+        val baseA = DefaultKinematicBase.create(
             kinematicGraph,
+            SimpleKinematicBaseId("BaseA"),
             NoopBodyController
         )
 

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/model/LinkConfigurationDataTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/model/LinkConfigurationDataTest.kt
@@ -1,0 +1,20 @@
+package com.neuronrobotics.bowlerkernel.kinematics.limb.link.model
+
+import arrow.core.right
+import com.neuronrobotics.bowlerkernel.kinematics.linkConfigurationData
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class LinkConfigurationDataTest {
+
+    @Test
+    fun `test json conversion`() {
+        val expected = linkConfigurationData()
+
+        val decoded = with(LinkConfigurationData.encoder()) {
+            expected.encode()
+        }.decode(LinkConfigurationData.decoder())
+
+        assertEquals(expected.right(), decoded)
+    }
+}

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/model/LinkConfigurationDataTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/model/LinkConfigurationDataTest.kt
@@ -1,3 +1,19 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.neuronrobotics.bowlerkernel.kinematics.limb.link.model
 
 import arrow.core.right

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/model/LinkScriptDataTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/link/model/LinkScriptDataTest.kt
@@ -1,0 +1,23 @@
+package com.neuronrobotics.bowlerkernel.kinematics.limb.link.model
+
+import arrow.core.right
+import com.beust.klaxon.Klaxon
+import com.neuronrobotics.bowlerkernel.kinematics.linkScriptData
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class LinkScriptDataTest {
+
+    @Test
+    fun `test json conversion`() {
+        val klaxon = Klaxon()
+
+        val expected = klaxon.linkScriptData()
+
+        val decoded = with(LinkScriptData.encoder()) {
+            expected.encode()
+        }.decode(LinkScriptData.decoder())
+
+        assertEquals(expected.right(), decoded)
+    }
+}

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/LimbConfigurationDataTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/LimbConfigurationDataTest.kt
@@ -1,0 +1,20 @@
+package com.neuronrobotics.bowlerkernel.kinematics.limb.model
+
+import arrow.core.right
+import com.neuronrobotics.bowlerkernel.kinematics.limbConfigurationData
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class LimbConfigurationDataTest {
+
+    @Test
+    fun `test json conversion`() {
+        val expected = limbConfigurationData()
+
+        val decoded = with(LimbConfigurationData.encoder()) {
+            expected.encode()
+        }.decode(LimbConfigurationData.decoder())
+
+        assertEquals(expected.right(), decoded)
+    }
+}

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/LimbConfigurationDataTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/LimbConfigurationDataTest.kt
@@ -1,3 +1,19 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.neuronrobotics.bowlerkernel.kinematics.limb.model
 
 import arrow.core.right

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/LimbScriptDataTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/LimbScriptDataTest.kt
@@ -1,0 +1,23 @@
+package com.neuronrobotics.bowlerkernel.kinematics.limb.model
+
+import arrow.core.right
+import com.beust.klaxon.Klaxon
+import com.neuronrobotics.bowlerkernel.kinematics.limbScriptData
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class LimbScriptDataTest {
+
+    @Test
+    fun `test json conversion`() {
+        val klaxon = Klaxon()
+
+        val expected = klaxon.limbScriptData()
+
+        val decoded = with(LimbScriptData.encoder()) {
+            expected.encode()
+        }.decode(LimbScriptData.decoder())
+
+        assertEquals(expected.right(), decoded)
+    }
+}

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/LimbScriptDataTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/model/LimbScriptDataTest.kt
@@ -1,3 +1,19 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.neuronrobotics.bowlerkernel.kinematics.limb.model
 
 import arrow.core.right

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/FrameTransformationTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/FrameTransformationTest.kt
@@ -19,7 +19,11 @@
 package com.neuronrobotics.bowlerkernel.kinematics.motion
 
 import Jama.Matrix
+import arrow.core.Either
 import com.beust.klaxon.Klaxon
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.LinkType
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.decoder
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.encoder
 import com.neuronrobotics.bowlerkernel.kinematics.testJsonConversion
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -482,5 +486,26 @@ internal class FrameTransformationTest {
     fun `test json`() {
         Klaxon().converter(FrameTransformation)
             .testJsonConversion(FrameTransformation.fromTranslation(10, 20, 30))
+    }
+
+    @Test
+    fun `test helios json`() {
+        val encoded = with(Enum.Companion.encoder<LinkType>()) {
+            LinkType.Rotary.encode()
+        }
+
+        encoded.decode(Enum.Companion.decoder<LinkType>()).let { println(it) }
+
+        val expected = FrameTransformation.fromTranslation(10, 20, 30)
+        val json = with(FrameTransformation) { expected.encode() }
+        val actual = json.decode(FrameTransformation)
+
+        assertAll(
+            { assertTrue(actual.isRight()) },
+            {
+                actual as Either.Right
+                assertEquals(expected, actual.b)
+            }
+        )
     }
 }

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/FrameTransformationTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/FrameTransformationTest.kt
@@ -21,9 +21,6 @@ package com.neuronrobotics.bowlerkernel.kinematics.motion
 import Jama.Matrix
 import arrow.core.Either
 import com.beust.klaxon.Klaxon
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.LinkType
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.decoder
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.encoder
 import com.neuronrobotics.bowlerkernel.kinematics.testJsonConversion
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -490,12 +487,6 @@ internal class FrameTransformationTest {
 
     @Test
     fun `test helios json`() {
-        val encoded = with(Enum.Companion.encoder<LinkType>()) {
-            LinkType.Rotary.encode()
-        }
-
-        encoded.decode(Enum.Companion.decoder<LinkType>()).let { println(it) }
-
         val expected = FrameTransformation.fromTranslation(10, 20, 30)
         val json = with(FrameTransformation) { expected.encode() }
         val actual = json.decode(FrameTransformation)

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.jvmargs=-XX:MaxPermSize=1g -XX:MaxMetaspaceSize=1g
 kotlin.version=1.3.40
 arrow.version=0.9.0
 github-api.version=1.95
-kt-guava-core.version=0.2.2
-kt-guava-klaxon.version=0.2.2
+kt-guava-core.version=0.2.3
+kt-guava-klaxon.version=0.2.3
 kotlin-guiced-core.version=0.0.5
 guice.version=4.1.0
 mockito-kotlin.version=2.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,4 @@ jama.version=1.0.3
 kotlin-logging.version=1.6.26
 slf4j-log4j12.version=1.7.26
 apache-log4j-extras.version=1.2.17
+helios.version=0.1.0

--- a/gradle/generated-kotlin-sources.gradle
+++ b/gradle/generated-kotlin-sources.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'idea'
+
+idea {
+    module {
+        sourceDirs += files(
+                'build/generated/source/kapt/main',
+                'build/generated/source/kaptKotlin/main',
+                'build/tmp/kapt/main/kotlinGenerated')
+        generatedSourceDirs += files(
+                'build/generated/source/kapt/main',
+                'build/generated/source/kaptKotlin/main',
+                'build/tmp/kapt/main/kotlinGenerated')
+    }
+}


### PR DESCRIPTION
### Description of the Change

This PR introduces `KinematicGraph`: a directed graph in which nodes are either bases or limbs and edges are frame transforms. This graph can model any type of kinematic structure. `DefaultKinematicBase` still acts on one base with `n` limbs, but a new implementation, `GeneralKinematicBase`, has been added (not yet implemented) which acts on the entire graph.

### Motivation

The stack should be able to support robots with multiple bases and parallel/hybrid manipulators. The previous model could not handle these.

### Possible Drawbacks

None.

### Verification Process

New tests were added for `KinematicGraph`.

### Applicable Issues

Closes #27.
