### PR TITLE
Use Blender to deduplicate vertices

### DIFF
--- a/bowler-kernel.gradle.kts
+++ b/bowler-kernel.gradle.kts
@@ -177,15 +177,19 @@ configure(javaProjects) {
             }
 
             /*
-             * Performance tests are only really run during development.
-             * They don't need to run in CI or as part of regular development.
+            These tests just test performance and should not run in CI.
              */
             excludeTags("performance")
 
             /*
-             * Marking a test as `slow` will excluded it from being run as part of the regular CI system.
+            These tests are too slow to run in CI.
              */
             excludeTags("slow")
+
+            /*
+            These tests need some sort of software that can't be reasonably installed on CI servers.
+             */
+            excludeTags("needsSpecialSoftware")
         }
 
         if (project.hasProperty("jenkinsBuild") || project.hasProperty("headless")) {

--- a/bowler-kernel/cad-core/src/main/kotlin/com/neuronrobotics/bowlerkernel/cad/core/BlenderDeduplicator.kt
+++ b/bowler-kernel/cad-core/src/main/kotlin/com/neuronrobotics/bowlerkernel/cad/core/BlenderDeduplicator.kt
@@ -1,0 +1,56 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.cad.core
+
+import eu.mihosoft.vrl.v3d.CSG
+import eu.mihosoft.vrl.v3d.STL
+import java.io.File
+import java.nio.file.Paths
+import java.text.NumberFormat
+import kotlin.random.Random
+
+class BlenderDeduplicator(
+    private val blenderExec: String = "blender",
+    private val dedupScript: File = File(BlenderDeduplicator::class.java.getResource("dedup.py").file)
+) : Deduplicator {
+
+    private val folder = dedupScript.parent
+
+    override fun deduplicate(csg: CSG, threshold: Double): CSG {
+        val filenamePrefix = Random.nextBytes(12).joinToString("")
+
+        File("$folder/$filenamePrefix.stl").writeText(csg.toStlString())
+
+        // Double.toString() would use scientific notation
+        val thresholdString = NumberFormat.getInstance().apply {
+            isGroupingUsed = false
+            maximumIntegerDigits = 999
+            maximumFractionDigits = 999
+        }.format(threshold)
+
+        val command = "$blenderExec --background --python $dedupScript -- " +
+            "$folder/$filenamePrefix.stl $folder/$filenamePrefix-deduped.stl $thresholdString"
+        Runtime.getRuntime().exec(command).waitFor()
+
+        val csgBack = STL.file(Paths.get("$folder/$filenamePrefix-deduped.stl"))
+
+        File("$folder/$filenamePrefix.stl").delete()
+        File("$folder/$filenamePrefix-deduped.stl").delete()
+
+        return csgBack
+    }
+}

--- a/bowler-kernel/cad-core/src/main/kotlin/com/neuronrobotics/bowlerkernel/cad/core/BlenderDeduplicator.kt
+++ b/bowler-kernel/cad-core/src/main/kotlin/com/neuronrobotics/bowlerkernel/cad/core/BlenderDeduplicator.kt
@@ -18,6 +18,7 @@ package com.neuronrobotics.bowlerkernel.cad.core
 
 import eu.mihosoft.vrl.v3d.CSG
 import eu.mihosoft.vrl.v3d.STL
+import mu.KotlinLogging
 import java.io.File
 import java.nio.file.Paths
 import java.text.NumberFormat
@@ -44,6 +45,7 @@ class BlenderDeduplicator(
 
         val command = "$blenderExec --background --python $dedupScript -- " +
             "$folder/$filenamePrefix.stl $folder/$filenamePrefix-deduped.stl $thresholdString"
+        LOGGER.debug { "Running command: `$command`" }
         Runtime.getRuntime().exec(command).waitFor()
 
         val csgBack = STL.file(Paths.get("$folder/$filenamePrefix-deduped.stl"))
@@ -52,5 +54,9 @@ class BlenderDeduplicator(
         File("$folder/$filenamePrefix-deduped.stl").delete()
 
         return csgBack
+    }
+
+    companion object {
+        private val LOGGER = KotlinLogging.logger { }
     }
 }

--- a/bowler-kernel/cad-core/src/main/kotlin/com/neuronrobotics/bowlerkernel/cad/core/Deduplicator.kt
+++ b/bowler-kernel/cad-core/src/main/kotlin/com/neuronrobotics/bowlerkernel/cad/core/Deduplicator.kt
@@ -25,7 +25,7 @@ interface Deduplicator {
      *
      * @param csg The CSG.
      * @param threshold The minimum closeness to remove.
-     * @return The simplified CSG>
+     * @return The simplified CSG.
      */
-    fun deduplicate(csg: CSG, threshold: Double = 0.0001): CSG
+    fun deduplicate(csg: CSG, threshold: Double = 1e-4): CSG
 }

--- a/bowler-kernel/cad-core/src/main/kotlin/com/neuronrobotics/bowlerkernel/cad/core/Deduplicator.kt
+++ b/bowler-kernel/cad-core/src/main/kotlin/com/neuronrobotics/bowlerkernel/cad/core/Deduplicator.kt
@@ -1,0 +1,31 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.cad.core
+
+import eu.mihosoft.vrl.v3d.CSG
+
+interface Deduplicator {
+
+    /**
+     * Deduplicate the vertices as close as (or closer than) [threshold].
+     *
+     * @param csg The CSG.
+     * @param threshold The minimum closeness to remove.
+     * @return The simplified CSG>
+     */
+    fun deduplicate(csg: CSG, threshold: Double = 0.0001): CSG
+}

--- a/bowler-kernel/cad-core/src/main/kotlin/com/neuronrobotics/bowlerkernel/cad/core/Deduplicator.kt
+++ b/bowler-kernel/cad-core/src/main/kotlin/com/neuronrobotics/bowlerkernel/cad/core/Deduplicator.kt
@@ -16,6 +16,7 @@
  */
 package com.neuronrobotics.bowlerkernel.cad.core
 
+import arrow.effects.IO
 import eu.mihosoft.vrl.v3d.CSG
 
 interface Deduplicator {
@@ -27,5 +28,5 @@ interface Deduplicator {
      * @param threshold The minimum closeness to remove.
      * @return The simplified CSG.
      */
-    fun deduplicate(csg: CSG, threshold: Double = 1e-4): CSG
+    fun deduplicate(csg: CSG, threshold: Double = 1e-4): IO<CSG>
 }

--- a/bowler-kernel/cad-core/src/main/resources/com/neuronrobotics/bowlerkernel/cad/core/dedup.py
+++ b/bowler-kernel/cad-core/src/main/resources/com/neuronrobotics/bowlerkernel/cad/core/dedup.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import bpy
+
+if bpy.context.space_data is None:
+    cwd = os.path.dirname(os.path.abspath(__file__))
+else:
+    cwd = os.path.dirname(bpy.context.space_data.text.filepath)
+
+# Get folder of script and add current working directory to path
+sys.path.append(cwd)
+
+
+def dedup_mesh(mesh_path: str, output_path: str, threshold: float):
+    scene = bpy.context.scene
+
+    # Select all mesh objects and delete them
+    for o in scene.objects:
+        if o.type == 'MESH':
+            o.select = True
+        else:
+            o.select = False
+    bpy.ops.object.delete()
+
+    bpy.ops.import_mesh.stl(filepath=mesh_path)
+    scene.objects.active = scene.objects[0]
+
+    bpy.ops.object.mode_set(mode='EDIT')
+    bpy.ops.mesh.remove_doubles(threshold=threshold)
+    bpy.ops.object.mode_set(mode='OBJECT')
+
+    bpy.ops.export_mesh.stl(filepath=output_path)
+
+
+def main(argv):
+    if len(argv) != 3:
+        sys.exit(2)
+
+    mesh_path = argv[0]
+    output_path = argv[1]
+    threshold = float(argv[2])
+
+    dedup_mesh(mesh_path, output_path, threshold)
+
+
+if __name__ == '__main__':
+    argv = sys.argv
+    argv = argv[argv.index("--") + 1:]  # get all args after "--"
+    main(argv)

--- a/bowler-kernel/cad-core/src/test/kotlin/com/neuronrobotics/bowlerkernel/cad/core/BlenderDeduplicatorTest.kt
+++ b/bowler-kernel/cad-core/src/test/kotlin/com/neuronrobotics/bowlerkernel/cad/core/BlenderDeduplicatorTest.kt
@@ -1,0 +1,41 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.cad.core
+
+import eu.mihosoft.vrl.v3d.Cylinder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+
+internal class BlenderDeduplicatorTest {
+
+    private val deduplicator = BlenderDeduplicator()
+
+    @Test
+    fun `test dedup`() {
+        val csg = Cylinder(50.0, 50.0, 100).toCSG().let { csg ->
+            csg.union((0 until 20).map { csg.rotz(it) })
+        }
+
+        val csgOut = deduplicator.deduplicate(csg)
+
+        assertAll(
+            { assertEquals(csg.bounds.center, csgOut.bounds.center) },
+            { assertEquals(csg.bounds.bounds, csgOut.bounds.bounds) }
+        )
+    }
+}

--- a/bowler-kernel/cad-core/src/test/kotlin/com/neuronrobotics/bowlerkernel/cad/core/BlenderDeduplicatorTest.kt
+++ b/bowler-kernel/cad-core/src/test/kotlin/com/neuronrobotics/bowlerkernel/cad/core/BlenderDeduplicatorTest.kt
@@ -20,6 +20,7 @@ import arrow.core.Either
 import eu.mihosoft.vrl.v3d.Cylinder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 
@@ -32,6 +33,7 @@ internal class BlenderDeduplicatorTest {
     }
 
     @Test
+    @Tag("needsSpecialSoftware")
     fun `test dedup`() {
         val csgOut = deduplicator.deduplicate(csg).attempt().unsafeRunSync()
 

--- a/bowler-kernel/cad-core/src/test/kotlin/com/neuronrobotics/bowlerkernel/cad/core/BlenderDeduplicatorTest.kt
+++ b/bowler-kernel/cad-core/src/test/kotlin/com/neuronrobotics/bowlerkernel/cad/core/BlenderDeduplicatorTest.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
+import java.io.IOException
 
 internal class BlenderDeduplicatorTest {
 
@@ -54,5 +55,7 @@ internal class BlenderDeduplicatorTest {
             .unsafeRunSync()
 
         assertTrue(result is Either.Left)
+        result as Either.Left
+        assertTrue(result.a is IOException)
     }
 }


### PR DESCRIPTION
### Description of the Change

This PR adds a python script that uses Blender to deduplicate vertices from CSGs.

### Motivation

This is a simple way to cut down on the size of CSGs, which has been getting out of control. This also opens an avenue towards using Blender for more complex mesh transformations.

### Possible Drawbacks

None. If the user does not have Blender installed, they can just `handleError { }` to return their original CSG.

### Verification Process

Unit testing and manual verification of the files, script, and simplified meshes.

### Applicable Issues

None.
