### PR TITLE
Support Teensy3.5 Device Type

### DIFF
--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DefaultDeviceTypes.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DefaultDeviceTypes.kt
@@ -93,6 +93,13 @@ sealed class DefaultDeviceTypes(
                     (p.pinNumbers[1] in digitalInPins && p.pinNumbers[0] in digitalOutPins))
     }
 
+    object Teensy35 : DefaultDeviceTypes("Teensy 3.5", 0, 58) {
+
+        override fun isResourceInRange(resourceId: ResourceId): Boolean {
+            TODO("not implemented")
+        }
+    }
+
     object UnknownDevice : DefaultDeviceTypes("Unknown Device", 0, 0) {
         override fun isResourceInRange(resourceId: ResourceId) = true
     }

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DefaultDeviceTypes.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DefaultDeviceTypes.kt
@@ -16,10 +16,7 @@
  */
 package com.neuronrobotics.bowlerkernel.hardware.device.deviceid
 
-import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultAttachmentPoints
-import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultResourceTypes
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.ResourceId
-import com.neuronrobotics.bowlerkernel.util.isAllUnique
 
 /**
  * The device types Bowler supports out-of-the-box.
@@ -32,65 +29,16 @@ sealed class DefaultDeviceTypes(
 
     object Esp32wroom32 : DefaultDeviceTypes("ESP32-WROOM-32", 0, 40) {
 
-        private val digitalInPins = listOf(
-            4, 14, 16, 17, 18, 19, 21, 22, 23, 25, 26, 27, 32, 33, 34, 35, 36, 39
-        ).map { it.toByte() }
-
-        private val digitalOutPins = listOf(
-            2, 4, 5, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 25, 26, 27, 32, 33
-        ).map { it.toByte() }
-
-        private val analogInPins = listOf(
-            4, 14, 16, 17, 18, 19, 21, 22, 23, 25, 26, 27, 32, 33, 34, 35, 36, 39
-        ).map { it.toByte() }
-
-        private val analogOutPins = listOf(
-            4, 5, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 25, 26, 27, 32, 33
-        ).map { it.toByte() }
-
-        private val serialPins = listOf(1, 3).map { it.toByte() }.toByteArray()
-
-        override fun isResourceInRange(resourceId: ResourceId): Boolean {
-            return when (val p = resourceId.attachmentPoint) {
-                is DefaultAttachmentPoints.Pin -> checkPin(p)
-                is DefaultAttachmentPoints.PinGroup -> checkPinGroup(resourceId, p)
-                else -> false
-            }
+        private val implementation = implementDeviceType(Esp32wroom32) {
+            digitalOut(2, 4..5, 12..19, 21..23, 25..27, 32..33)
+            digitalIn(4, 14, 16..19, 21..23, 25..27, 32..36, 39)
+            analogOut(4, 5, 12..19, 21..23, 25..27, 32..33)
+            analogIn(4, 14, 16..19, 21..23, 25..27, 32..36, 39)
+            serial(1 to 3)
         }
 
-        private fun checkPin(p: DefaultAttachmentPoints.Pin) =
-            p.pinNumber in digitalInPins ||
-                p.pinNumber in digitalOutPins ||
-                p.pinNumber in analogInPins ||
-                p.pinNumber in analogOutPins
-
-        private fun checkPinGroup(
-            resourceId: ResourceId,
-            p: DefaultAttachmentPoints.PinGroup
-        ) = when (resourceId.resourceType) {
-            is DefaultResourceTypes.Encoder -> checkEncoder(p)
-            is DefaultResourceTypes.SerialConnection -> checkSerial(p)
-            is DefaultResourceTypes.Ultrasonic -> checkUltrasonic(p)
-            is DefaultResourceTypes.Stepper -> checkStepper(p)
-            else -> false
-        }
-
-        private fun checkStepper(p: DefaultAttachmentPoints.PinGroup) =
-            p.pinNumbers.isAllUnique() &&
-                p.pinNumbers.size in listOf(2, 4, 5) &&
-                p.pinNumbers.all { it in digitalOutPins }
-
-        private fun checkEncoder(p: DefaultAttachmentPoints.PinGroup) =
-            p.pinNumbers.isAllUnique() && p.pinNumbers.all { it in digitalInPins }
-
-        private fun checkSerial(p: DefaultAttachmentPoints.PinGroup) =
-            p.pinNumbers.isAllUnique() && p.pinNumbers.all { it in serialPins }
-
-        @SuppressWarnings("UnnecessaryParentheses")
-        private fun checkUltrasonic(p: DefaultAttachmentPoints.PinGroup) =
-            p.pinNumbers.isAllUnique() && p.pinNumbers.size == 2 &&
-                ((p.pinNumbers[0] in digitalInPins && p.pinNumbers[1] in digitalOutPins) ||
-                    (p.pinNumbers[1] in digitalInPins && p.pinNumbers[0] in digitalOutPins))
+        override fun isResourceInRange(resourceId: ResourceId) =
+            implementation.isResourceInRange(resourceId)
     }
 
     object Teensy35 : DefaultDeviceTypes("Teensy 3.5", 0, 58) {

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DefaultDeviceTypes.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DefaultDeviceTypes.kt
@@ -29,7 +29,7 @@ sealed class DefaultDeviceTypes(
 
     object Esp32wroom32 : DefaultDeviceTypes("ESP32-WROOM-32", 0, 40) {
 
-        private val implementation = implementDeviceType(Esp32wroom32) {
+        private val implementation = implementDeviceType {
             digitalOut(2, 4..5, 12..19, 21..23, 25..27, 32..33)
             digitalIn(4, 14, 16..19, 21..23, 25..27, 32..36, 39)
             analogOut(4, 5, 12..19, 21..23, 25..27, 32..33)
@@ -43,7 +43,7 @@ sealed class DefaultDeviceTypes(
 
     object Teensy35 : DefaultDeviceTypes("Teensy 3.5", 0, 58) {
 
-        private val implementation = implementDeviceType(Teensy35) {
+        private val implementation = implementDeviceType {
             digitalOut(0..57)
             digitalIn(0..57)
             analogOut(2..10, 14, 20..23, 29..30, 35..38)

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DefaultDeviceTypes.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DefaultDeviceTypes.kt
@@ -95,9 +95,16 @@ sealed class DefaultDeviceTypes(
 
     object Teensy35 : DefaultDeviceTypes("Teensy 3.5", 0, 58) {
 
-        override fun isResourceInRange(resourceId: ResourceId): Boolean {
-            TODO("not implemented")
+        private val implementation = implementDeviceType(Teensy35) {
+            digitalOut(0..57)
+            digitalIn(0..57)
+            analogOut(2..10, 14, 20..23, 29..30, 35..38)
+            analogIn(0..26)
+            serial(1 to 0, 10 to 9, 8 to 7, 32 to 31, 33 to 34, 48 to 47)
         }
+
+        override fun isResourceInRange(resourceId: ResourceId) =
+            implementation.isResourceInRange(resourceId)
     }
 
     object UnknownDevice : DefaultDeviceTypes("Unknown Device", 0, 0) {

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DeviceTypeDsl.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DeviceTypeDsl.kt
@@ -27,9 +27,7 @@ import com.neuronrobotics.bowlerkernel.util.isAllUnique
 annotation class DeviceTypeDsl
 
 @DeviceTypeDsl
-class DeviceTypeImplementation(
-    private val type: DefaultDeviceTypes
-) {
+class DeviceTypeImplementation {
 
     private lateinit var digitalInPins: List<Byte>
     private lateinit var digitalOutPins: List<Byte>
@@ -177,10 +175,9 @@ private fun ByteArray.asTuple2(): Tuple2<Byte, Byte> {
 
 @DeviceTypeDsl
 fun implementDeviceType(
-    type: DefaultDeviceTypes,
     configure: DeviceTypeImplementation.() -> Unit
 ): DeviceTypeImplementation {
-    val scenario = DeviceTypeImplementation(type)
+    val scenario = DeviceTypeImplementation()
     scenario.configure()
     return scenario
 }

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DeviceTypeDsl.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DeviceTypeDsl.kt
@@ -1,0 +1,186 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.hardware.device.deviceid
+
+import arrow.core.Tuple2
+import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultAttachmentPoints
+import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultResourceTypes
+import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.ResourceId
+import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.ResourceType
+import com.neuronrobotics.bowlerkernel.util.isAllUnique
+
+@DslMarker
+annotation class DeviceTypeDsl
+
+@DeviceTypeDsl
+class DeviceTypeImplementation(
+    private val type: DefaultDeviceTypes
+) {
+
+    private lateinit var digitalInPins: List<Byte>
+    private lateinit var digitalOutPins: List<Byte>
+    private lateinit var analogInPins: List<Byte>
+    private lateinit var analogOutPins: List<Byte>
+    private lateinit var serialPins: List<Tuple2<Byte, Byte>>
+
+    private val singlePinResources = listOf(
+        DefaultResourceTypes.DigitalIn,
+        DefaultResourceTypes.DigitalOut,
+        DefaultResourceTypes.AnalogIn,
+        DefaultResourceTypes.AnalogOut,
+        DefaultResourceTypes.Servo,
+        DefaultResourceTypes.Encoder,
+        DefaultResourceTypes.Button,
+        DefaultResourceTypes.PiezoelectricSpeaker
+    )
+
+    private val multiPinResources = listOf(
+        DefaultResourceTypes.SerialConnection,
+        DefaultResourceTypes.Stepper,
+        DefaultResourceTypes.Encoder,
+        DefaultResourceTypes.Ultrasonic
+    )
+
+    fun isResourceInRange(resourceId: ResourceId): Boolean {
+        return when (val p = resourceId.attachmentPoint) {
+            is DefaultAttachmentPoints.Pin -> checkPin(resourceId.resourceType, p)
+            is DefaultAttachmentPoints.PinGroup -> checkPinGroup(resourceId.resourceType, p)
+            else -> true // Assume the user is correct
+        }
+    }
+
+    private fun checkPin(
+        type: ResourceType,
+        pin: DefaultAttachmentPoints.Pin
+    ): Boolean = when (type) {
+        in singlePinResources -> when (type) {
+            is DefaultResourceTypes.DigitalIn, DefaultResourceTypes.Encoder,
+            DefaultResourceTypes.Button ->
+                pin.pinNumber in digitalInPins
+
+            is DefaultResourceTypes.DigitalOut, DefaultResourceTypes.PiezoelectricSpeaker ->
+                pin.pinNumber in digitalOutPins
+
+            is DefaultResourceTypes.AnalogIn -> pin.pinNumber in analogInPins
+
+            is DefaultResourceTypes.AnalogOut, DefaultResourceTypes.Servo ->
+                pin.pinNumber in analogOutPins
+
+            is DefaultResourceTypes.Ultrasonic -> pin.pinNumber in digitalInPins &&
+                pin.pinNumber in digitalOutPins
+
+            else -> throw IllegalStateException("The implementation is missing a resource.")
+        }
+
+        else -> true // Assume the user is correct
+    }
+
+    private fun checkPinGroup(
+        type: ResourceType,
+        pinGroup: DefaultAttachmentPoints.PinGroup
+    ): Boolean = when (type) {
+        in multiPinResources -> {
+            if (pinGroup.pinNumbers.isAllUnique()) {
+                when (type) {
+                    is DefaultResourceTypes.SerialConnection -> pinGroup.twoPins() &&
+                        pinGroup.pinNumbers.asTuple2().let {
+                            it in serialPins || it.reverse() in serialPins
+                        }
+
+                    is DefaultResourceTypes.Encoder -> pinGroup.twoPins() &&
+                        pinGroup.pinNumbers allIn digitalInPins
+
+                    is DefaultResourceTypes.Ultrasonic -> pinGroup.twoPins() &&
+                        pinGroup.pinNumbers.let {
+                            it[0] in digitalInPins && it[1] in digitalOutPins ||
+                                it[1] in digitalInPins && it[0] in digitalOutPins
+                        }
+
+                    is DefaultResourceTypes.Stepper -> stepperTwoPins(pinGroup) ||
+                        stepperFourPins(pinGroup) || stepperFivePins(pinGroup)
+
+                    else -> throw IllegalStateException("The implementation is missing a resource.")
+                }
+            } else {
+                // Not all unique pins
+                false
+            }
+        }
+
+        else -> true // Assume the user is correct
+    }
+
+    private fun stepperTwoPins(pinGroup: DefaultAttachmentPoints.PinGroup): Boolean =
+        pinGroup.twoPins() && pinGroup.pinNumbers allIn digitalOutPins
+
+    private fun stepperFourPins(pinGroup: DefaultAttachmentPoints.PinGroup): Boolean =
+        pinGroup.fourPins() && pinGroup.pinNumbers allIn digitalOutPins
+
+    private fun stepperFivePins(pinGroup: DefaultAttachmentPoints.PinGroup): Boolean =
+        pinGroup.fivePins() && pinGroup.pinNumbers allIn digitalOutPins
+
+    fun digitalIn(vararg pins: Any) {
+        digitalInPins = pins.collectPins()
+    }
+
+    fun digitalOut(vararg pins: Any) {
+        digitalOutPins = pins.collectPins()
+    }
+
+    fun analogIn(vararg pins: Any) {
+        analogInPins = pins.collectPins()
+    }
+
+    fun analogOut(vararg pins: Any) {
+        analogOutPins = pins.collectPins()
+    }
+
+    fun serial(vararg pins: Pair<Number, Number>) {
+        serialPins = pins.map { Tuple2(it.first.toByte(), it.second.toByte()) }.toSet().toList()
+    }
+
+    private fun Array<out Any>.collectPins() = flatMap {
+        when (it) {
+            is Int -> listOf(it.toByte())
+            is IntRange -> it.map(Int::toByte)
+            else -> throw IllegalStateException("Unknown pin input: $it")
+        }
+    }.toSet().toList()
+}
+
+private infix fun ByteArray.allIn(list: Iterable<Byte>) = all { list.contains(it) }
+
+private fun DefaultAttachmentPoints.PinGroup.twoPins() = pinNumbers.size == 2
+
+private fun DefaultAttachmentPoints.PinGroup.fourPins() = pinNumbers.size == 4
+
+private fun DefaultAttachmentPoints.PinGroup.fivePins() = pinNumbers.size == 5
+
+private fun ByteArray.asTuple2(): Tuple2<Byte, Byte> {
+    require(size == 2)
+    return Tuple2(this[0], this[1])
+}
+
+@DeviceTypeDsl
+fun implementDeviceType(
+    type: DefaultDeviceTypes,
+    configure: DeviceTypeImplementation.() -> Unit
+): DeviceTypeImplementation {
+    val scenario = DeviceTypeImplementation(type)
+    scenario.configure()
+    return scenario
+}

--- a/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DeviceTypeTestingDsl.kt
+++ b/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/DeviceTypeTestingDsl.kt
@@ -21,6 +21,7 @@ import arrow.core.Tuple4
 import arrow.core.Tuple5
 import arrow.data.ListK
 import arrow.data.extensions.listk.applicative.applicative
+import arrow.data.extensions.sequence.applicative.product
 import arrow.data.fix
 import arrow.data.k
 import com.neuronrobotics.bowlerkernel.hardware.deviceresource.resourceid.DefaultAttachmentPoints
@@ -86,7 +87,7 @@ internal class DeviceTypeScenario(
     }
 
     private fun assertDisallowedPins() {
-        val disallowedPins = (type.firstPinNumber until type.numberOfPins).toList()
+        val disallowedPins = (type.firstPinNumber until type.numberOfPins)
             .map { it.toByte() } - digitalInPins - digitalOutPins - analogInPins - analogOutPins -
             serialPins.flatMap { listOf(it.a, it.b) }
 
@@ -100,16 +101,14 @@ internal class DeviceTypeScenario(
         ListK.applicative()
             .tupled(disallowedPins.k(), disallowedPins.k())
             .fix()
-            .forEach {
-                assertDisallowed(DefaultResourceTypes.SerialConnection, it)
-            }
+            .map { it.toList() }
+            .forEach { assertDisallowed(DefaultResourceTypes.SerialConnection, it) }
 
         ListK.applicative()
             .tupled(disallowedPins.k(), disallowedPins.k())
             .fix()
-            .forEach {
-                assertDisallowed(DefaultResourceTypes.Encoder, it)
-            }
+            .map { it.toList() }
+            .forEach { assertDisallowed(DefaultResourceTypes.Encoder, it) }
 
         assertDisallowedSteppers(disallowedPins)
     }
@@ -118,16 +117,14 @@ internal class DeviceTypeScenario(
         ListK.applicative()
             .tupled(disallowedPins.k(), disallowedPins.k())
             .fix()
-            .forEach {
-                assertDisallowed(DefaultResourceTypes.Stepper, it)
-            }
+            .map { it.toList() }
+            .forEach { assertDisallowed(DefaultResourceTypes.Stepper, it) }
 
         ListK.applicative()
             .tupled(disallowedPins.k(), disallowedPins.k(), disallowedPins.k(), disallowedPins.k())
             .fix()
-            .forEach {
-                assertDisallowed(DefaultResourceTypes.Stepper, it)
-            }
+            .map { it.toList() }
+            .forEach { assertDisallowed(DefaultResourceTypes.Stepper, it) }
 
         ListK.applicative()
             .tupled(
@@ -138,17 +135,16 @@ internal class DeviceTypeScenario(
                 disallowedPins.k()
             )
             .fix()
-            .forEach {
-                assertDisallowed(DefaultResourceTypes.Stepper, it)
-            }
+            .map { it.toList() }
+            .forEach { assertDisallowed(DefaultResourceTypes.Stepper, it) }
     }
 
     private fun assertSerial() {
         serialPins.forEach {
-            assertAllowed(DefaultResourceTypes.SerialConnection, it)
-            assertAllowed(DefaultResourceTypes.SerialConnection, it.reverse())
-            assertDisallowed(DefaultResourceTypes.SerialConnection, Tuple2(it.a, it.a))
-            assertDisallowed(DefaultResourceTypes.SerialConnection, Tuple2(it.b, it.b))
+            assertAllowed(DefaultResourceTypes.SerialConnection, it.toList())
+            assertAllowed(DefaultResourceTypes.SerialConnection, it.reverse().toList())
+            assertDisallowed(DefaultResourceTypes.SerialConnection, Tuple2(it.a, it.a).toList())
+            assertDisallowed(DefaultResourceTypes.SerialConnection, Tuple2(it.b, it.b).toList())
         }
     }
 
@@ -156,11 +152,12 @@ internal class DeviceTypeScenario(
         ListK.applicative()
             .tupled(digitalInPins.k(), digitalInPins.k())
             .fix()
+            .map { it.toList() }
             .forEach {
-                if (it.a == it.b) {
-                    assertDisallowed(DefaultResourceTypes.Encoder, it)
-                } else {
+                if (it.isAllUnique()) {
                     assertAllowed(DefaultResourceTypes.Encoder, it)
+                } else {
+                    assertDisallowed(DefaultResourceTypes.Encoder, it)
                 }
             }
     }
@@ -174,46 +171,55 @@ internal class DeviceTypeScenario(
         ListK.applicative()
             .tupled(digitalInPins.k(), digitalOutPins.k())
             .fix()
+            .map { it.toList() }
             .forEach {
-                if (it.a == it.b) {
-                    assertDisallowed(DefaultResourceTypes.Ultrasonic, it)
-                } else {
+                if (it.isAllUnique()) {
                     assertAllowed(DefaultResourceTypes.Ultrasonic, it)
-                    assertAllowed(DefaultResourceTypes.Ultrasonic, it.reverse())
+                    assertAllowed(DefaultResourceTypes.Ultrasonic, it.reversed())
+                } else {
+                    assertDisallowed(DefaultResourceTypes.Ultrasonic, it)
                 }
             }
     }
 
     private fun assertStepper() {
-        ListK.applicative()
-            .tupled(digitalOutPins.k(), digitalOutPins.k())
-            .fix()
-            .filter { it.a != it.b }
-            .forEach {
-                assertAllowed(DefaultResourceTypes.Stepper, it)
-            }
+        val edgeCasePins = digitalOutPins.firstFive() + digitalOutPins.lastFive()
 
-        ListK.applicative()
-            .tupled(digitalOutPins.k(), digitalOutPins.k(), digitalOutPins.k(), digitalOutPins.k())
-            .fix()
-            .filter { it.allUnique() }
-            .forEach {
-                assertAllowed(DefaultResourceTypes.Stepper, it)
-            }
+        edgeCasePins.asSequence().k().let {
+            it.product(it)
+        }.map { it.toList() }
+            .filter { it.isAllUnique() }
+            .forEach { assertAllowed(DefaultResourceTypes.Stepper, it) }
 
-        ListK.applicative()
-            .tupled(
-                digitalOutPins.k(),
-                digitalOutPins.k(),
-                digitalOutPins.k(),
-                digitalOutPins.k(),
-                digitalOutPins.k()
-            )
-            .fix()
-            .filter { it.allUnique() }
-            .forEach {
-                assertAllowed(DefaultResourceTypes.Stepper, it)
-            }
+        edgeCasePins.asSequence().k().let {
+            it.product(it).product(it).product(it)
+        }.map { it.toList() }
+            .filter { it.isAllUnique() }
+            .forEach { assertAllowed(DefaultResourceTypes.Stepper, it) }
+
+        edgeCasePins.asSequence().k().let {
+            it.product(it).product(it).product(it).product(it)
+        }.map { it.toList() }
+            .filter { it.isAllUnique() }
+            .forEach { assertAllowed(DefaultResourceTypes.Stepper, it) }
+
+        digitalOutPins.asSequence().k().let {
+            it.product(it)
+        }.map { it.toList() }
+            .filter { it.isAllUnique() }
+            .checkFirstNPins(DefaultResourceTypes.Stepper)
+
+        digitalOutPins.asSequence().k().let {
+            it.product(it).product(it).product(it)
+        }.map { it.toList() }
+            .filter { it.isAllUnique() }
+            .checkFirstNPins(DefaultResourceTypes.Stepper)
+
+        digitalOutPins.asSequence().k().let {
+            it.product(it).product(it).product(it).product(it)
+        }.map { it.toList() }
+            .filter { it.isAllUnique() }
+            .checkFirstNPins(DefaultResourceTypes.Stepper)
     }
 
     fun digitalIn(vararg pins: Any) {
@@ -244,45 +250,31 @@ internal class DeviceTypeScenario(
         }
     }.toSet().toList()
 
+    private fun Sequence<List<Byte>>.checkFirstNPins(
+        type: DefaultResourceTypes,
+        count: Int = 1000
+    ) {
+        // Check the first count pins
+        var index = 0
+        for (elem in this) {
+            if (index >= count) {
+                return
+            }
+
+            assertAllowed(type, elem)
+
+            index++
+        }
+    }
+
     private fun assertAllowed(resourceType: DefaultResourceTypes, pin: Byte) =
         assertAllowed(resourceType, DefaultAttachmentPoints.Pin(pin))
 
-    private fun assertAllowed(resourceType: DefaultResourceTypes, pinGroup: Tuple2<Byte, Byte>) =
+    private fun assertAllowed(resourceType: DefaultResourceTypes, pinGroup: List<Byte>) =
         assertAllowed(
             resourceType,
-            DefaultAttachmentPoints.PinGroup(byteArrayOf(pinGroup.a, pinGroup.b))
+            DefaultAttachmentPoints.PinGroup(pinGroup.toByteArray())
         )
-
-    private fun assertAllowed(
-        resourceType: DefaultResourceTypes,
-        pinGroup: Tuple4<Byte, Byte, Byte, Byte>
-    ) = assertAllowed(
-        resourceType,
-        DefaultAttachmentPoints.PinGroup(
-            byteArrayOf(
-                pinGroup.a,
-                pinGroup.b,
-                pinGroup.c,
-                pinGroup.d
-            )
-        )
-    )
-
-    private fun assertAllowed(
-        resourceType: DefaultResourceTypes,
-        pinGroup: Tuple5<Byte, Byte, Byte, Byte, Byte>
-    ) = assertAllowed(
-        resourceType,
-        DefaultAttachmentPoints.PinGroup(
-            byteArrayOf(
-                pinGroup.a,
-                pinGroup.b,
-                pinGroup.c,
-                pinGroup.d,
-                pinGroup.e
-            )
-        )
-    )
 
     private fun assertAllowed(
         resourceType: DefaultResourceTypes,
@@ -301,41 +293,10 @@ internal class DeviceTypeScenario(
 
     private fun assertDisallowed(
         resourceType: DefaultResourceTypes,
-        pinGroup: Tuple2<Byte, Byte>
+        pinGroup: List<Byte>
     ) = assertDisallowed(
         resourceType,
-        DefaultAttachmentPoints.PinGroup(byteArrayOf(pinGroup.a, pinGroup.b))
-    )
-
-    private fun assertDisallowed(
-        resourceType: DefaultResourceTypes,
-        pinGroup: Tuple4<Byte, Byte, Byte, Byte>
-    ) = assertDisallowed(
-        resourceType,
-        DefaultAttachmentPoints.PinGroup(
-            byteArrayOf(
-                pinGroup.a,
-                pinGroup.b,
-                pinGroup.c,
-                pinGroup.d
-            )
-        )
-    )
-
-    private fun assertDisallowed(
-        resourceType: DefaultResourceTypes,
-        pinGroup: Tuple5<Byte, Byte, Byte, Byte, Byte>
-    ) = assertDisallowed(
-        resourceType,
-        DefaultAttachmentPoints.PinGroup(
-            byteArrayOf(
-                pinGroup.a,
-                pinGroup.b,
-                pinGroup.c,
-                pinGroup.d,
-                pinGroup.e
-            )
-        )
+        DefaultAttachmentPoints.PinGroup(pinGroup.toByteArray())
     )
 
     private fun assertDisallowed(
@@ -349,8 +310,19 @@ internal class DeviceTypeScenario(
     }
 }
 
-private fun <A, B, C, D> Tuple4<A, B, C, D>.allUnique() = listOf(a, b, c, d).isAllUnique()
-private fun <A, B, C, D, E> Tuple5<A, B, C, D, E>.allUnique() = listOf(a, b, c, d, e).isAllUnique()
+private fun <A> Tuple2<A, A>.toList(): List<A> = listOf(a, b)
+private fun <A> Tuple4<A, A, A, A>.toList(): List<A> = listOf(a, b, c, d)
+private fun <A> Tuple5<A, A, A, A, A>.toList(): List<A> = listOf(a, b, c, d, e)
+
+private fun <E> List<E>.firstFive(): List<E> {
+    val endIndex = if (size <= 4) size else 5
+    return subList(0, endIndex)
+}
+
+private fun <E> List<E>.lastFive(): List<E> {
+    val startIndex = if (size - 5 < 0) 0 else size - 5
+    return subList(startIndex, size)
+}
 
 @DeviceTypeTestDsl
 internal fun deviceTypeTest(

--- a/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/Teensy35Test.kt
+++ b/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/device/deviceid/Teensy35Test.kt
@@ -1,0 +1,36 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.hardware.device.deviceid
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+internal class Teensy35Test {
+
+    @Test
+    fun `test dsl`() {
+        deviceTypeTest(DefaultDeviceTypes.Teensy35) {
+            digitalOut(0..57)
+            digitalIn(0..57)
+            analogOut(2..10, 14, 20..23, 29..30, 35..38)
+            analogIn(0..26)
+            serial(1 to 0, 10 to 9, 8 to 7, 32 to 31, 33 to 34, 48 to 47)
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,8 @@ dokkaPluginVersion=0.9.18
 testloggerPluginVersion=1.6.0
 pitestPluginVersion=1.4.0
 javafxpluginPluginVersion=0.0.8
-
 ktlint.version=0.29.0
+
 junit-jupiter.version=5.5.1
 junit-platform-launcher.version=1.5.1
 jacoco-tool.version=0.8.3


### PR DESCRIPTION
### Description of the Change

This PR adds support for the Teensy3.5 as a `DeviceType`. Not entirely sure if the support is fully complete (definitely not on the embedded RPC half) because I worked on this a few months ago and forgot about it.

### Motivation

Hopefully we can move from the esp32 to the teensy3.x with SmallKat.

### Possible Drawbacks

None.

### Verification Process

New tests.

### Applicable Issues

None.
