### PR TITLE
Improve reachability calculator

### DIFF
--- a/bowler-kernel/kinematics/kinematics.gradle.kts
+++ b/bowler-kernel/kinematics/kinematics.gradle.kts
@@ -80,4 +80,9 @@ dependencies {
         name = "mockito-kotlin",
         version = property("mockito-kotlin.version") as String
     )
+    testImplementation(
+        group = "io.mockk",
+        name = "mockk",
+        version = property("mockk.version") as String
+    )
 }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/closedloop/JointAngleController.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/closedloop/JointAngleController.kt
@@ -27,7 +27,7 @@ interface JointAngleController {
     /**
      * The limits of this joint in degrees.
      */
-    var jointLimits: JointLimits
+    val jointLimits: JointLimits
 
     /**
      * Move to the target [angle].

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/closedloop/NoopJointAngleController.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/closedloop/NoopJointAngleController.kt
@@ -24,7 +24,7 @@ import com.neuronrobotics.bowlerkernel.util.JointLimits
  */
 object NoopJointAngleController : JointAngleController {
 
-    override val jointLimits: JointLimits = JointLimits(180, -180)
+    override var jointLimits: JointLimits = JointLimits(180, -180)
 
     @SuppressWarnings("EmptyFunctionBlock")
     override fun setTargetAngle(angle: Double, motionConstraints: MotionConstraints) {

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/closedloop/NoopJointAngleController.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/closedloop/NoopJointAngleController.kt
@@ -24,7 +24,7 @@ import com.neuronrobotics.bowlerkernel.util.JointLimits
  */
 object NoopJointAngleController : JointAngleController {
 
-    override var jointLimits: JointLimits = JointLimits(180, -180)
+    override val jointLimits: JointLimits = JointLimits(180, -180)
 
     @SuppressWarnings("EmptyFunctionBlock")
     override fun setTargetAngle(angle: Double, motionConstraints: MotionConstraints) {

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/DefaultLimb.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/limb/DefaultLimb.kt
@@ -103,7 +103,10 @@ class DefaultLimb(
         jointAngleControllers.map { it.getCurrentAngle() }.toImmutableList()
 
     override fun isTaskSpaceTransformReachable(taskSpaceTransform: FrameTransformation) =
-        reachabilityCalculator.isFrameTransformationReachable(taskSpaceTransform, links)
+        reachabilityCalculator.isFrameTransformationReachable(
+            taskSpaceTransform,
+            links,
+            jointAngleControllers.map { it.jointLimits })
 
     override fun getInertialState() = inertialStateEstimator.getInertialState()
 

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthAndIKBasedReachabilityCalculator.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthAndIKBasedReachabilityCalculator.kt
@@ -1,0 +1,51 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerkernel.kinematics.motion
+
+import arrow.effects.IO
+import com.google.common.collect.ImmutableList
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.Link
+import com.neuronrobotics.bowlerkernel.kinematics.limb.link.toFrameTransformation
+import com.neuronrobotics.bowlerkernel.util.JointLimits
+
+/**
+ * Uses a [LengthBasedReachabilityCalculator] and an [InverseKinematicsSolver] to determine if
+ * a [FrameTransformation] is reachable.
+ */
+class LengthAndIKBasedReachabilityCalculator(
+    private val inverseKinematicsSolver: InverseKinematicsSolver,
+    private val lengthBasedReachabilityCalculator: LengthBasedReachabilityCalculator =
+        LengthBasedReachabilityCalculator()
+) : ReachabilityCalculator {
+
+    override fun isFrameTransformationReachable(
+        frameTransformation: FrameTransformation,
+        links: List<Link>,
+        jointLimits: List<JointLimits>
+    ): Boolean = lengthBasedReachabilityCalculator.isFrameTransformationReachable(
+        frameTransformation,
+        links,
+        jointLimits
+    ) && IO {
+        inverseKinematicsSolver.solveChain(
+            links,
+            links.map { 0.0 },
+            jointLimits,
+            frameTransformation
+        )
+    }.attempt().unsafeRunSync().isRight()
+}

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthAndIKBasedReachabilityCalculator.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthAndIKBasedReachabilityCalculator.kt
@@ -17,9 +17,7 @@
 package com.neuronrobotics.bowlerkernel.kinematics.motion
 
 import arrow.effects.IO
-import com.google.common.collect.ImmutableList
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.Link
-import com.neuronrobotics.bowlerkernel.kinematics.limb.link.toFrameTransformation
 import com.neuronrobotics.bowlerkernel.util.JointLimits
 
 /**

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthBasedReachabilityCalculator.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthBasedReachabilityCalculator.kt
@@ -19,6 +19,7 @@ package com.neuronrobotics.bowlerkernel.kinematics.motion
 import com.google.common.collect.ImmutableList
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.Link
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.toFrameTransformation
+import com.neuronrobotics.bowlerkernel.util.JointLimits
 
 /**
  * A simple implementation using only the distance to the transform from the origin and the
@@ -28,8 +29,9 @@ class LengthBasedReachabilityCalculator : ReachabilityCalculator {
 
     override fun isFrameTransformationReachable(
         frameTransformation: FrameTransformation,
-        links: ImmutableList<Link>
-    ) = frameTransformation.translation.length() <=
+        links: List<Link>,
+        jointLimits: List<JointLimits>
+    ): Boolean = frameTransformation.translation.length() <=
         links.map { it.dhParam }.toFrameTransformation().translation.length()
 
     override fun equals(other: Any?): Boolean {

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthBasedReachabilityCalculator.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthBasedReachabilityCalculator.kt
@@ -16,7 +16,6 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics.motion
 
-import com.google.common.collect.ImmutableList
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.Link
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.toFrameTransformation
 import com.neuronrobotics.bowlerkernel.util.JointLimits

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/ReachabilityCalculator.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/ReachabilityCalculator.kt
@@ -18,6 +18,7 @@ package com.neuronrobotics.bowlerkernel.kinematics.motion
 
 import com.google.common.collect.ImmutableList
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.Link
+import com.neuronrobotics.bowlerkernel.util.JointLimits
 
 /**
  * Determines whether a frame transform is reachable.
@@ -29,10 +30,12 @@ interface ReachabilityCalculator {
      *
      * @param frameTransformation The task space transform to test.
      * @param links The links that make up the limb.
+     * @param jointLimits The joint limits for each link.
      * @return Whether the [frameTransformation] is reachable.
      */
     fun isFrameTransformationReachable(
         frameTransformation: FrameTransformation,
-        links: ImmutableList<Link>
+        links: List<Link>,
+        jointLimits: List<JointLimits>
     ): Boolean
 }

--- a/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/ReachabilityCalculator.kt
+++ b/bowler-kernel/kinematics/src/main/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/ReachabilityCalculator.kt
@@ -16,7 +16,6 @@
  */
 package com.neuronrobotics.bowlerkernel.kinematics.motion
 
-import com.google.common.collect.ImmutableList
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.Link
 import com.neuronrobotics.bowlerkernel.util.JointLimits
 

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/MockJointAngleController.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/MockJointAngleController.kt
@@ -25,7 +25,7 @@ internal class MockJointAngleController : JointAngleController {
     internal val times = mutableListOf<Long>()
     internal val targets = mutableListOf<Double>()
 
-    override var jointLimits: JointLimits = JointLimits(180, -180)
+    override val jointLimits: JointLimits = JointLimits(180, -180)
 
     override fun setTargetAngle(angle: Double, motionConstraints: MotionConstraints) {
         times.add(System.currentTimeMillis())

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthAndIKBasedReachabilityCalculatorTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthAndIKBasedReachabilityCalculatorTest.kt
@@ -1,3 +1,19 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.neuronrobotics.bowlerkernel.kinematics.motion
 
 import com.neuronrobotics.bowlerkernel.kinematics.randomFrameTransformation
@@ -7,9 +23,10 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verifyOrder
-import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.Test
 import java.lang.IllegalStateException
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 internal class LengthAndIKBasedReachabilityCalculatorTest {
 

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthAndIKBasedReachabilityCalculatorTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthAndIKBasedReachabilityCalculatorTest.kt
@@ -1,0 +1,87 @@
+package com.neuronrobotics.bowlerkernel.kinematics.motion
+
+import com.neuronrobotics.bowlerkernel.kinematics.randomFrameTransformation
+import com.neuronrobotics.bowlerkernel.kinematics.seaArmLinks
+import com.neuronrobotics.bowlerkernel.util.JointLimits
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verifyOrder
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.lang.IllegalStateException
+
+internal class LengthAndIKBasedReachabilityCalculatorTest {
+
+    @Test
+    fun `both methods return true`() {
+        val ft = randomFrameTransformation()
+        val links = seaArmLinks
+        val jointLimits = links.map { JointLimits.NoLimit }
+
+        val mockCalc = mockk<LengthBasedReachabilityCalculator> {
+            every { isFrameTransformationReachable(ft, links, any()) } returns true
+        }
+
+        val mockIK = mockk<InverseKinematicsSolver> {
+            every { solveChain(links, any(), jointLimits, ft) } returns links.map { 0.0 }
+        }
+
+        val calc = LengthAndIKBasedReachabilityCalculator(mockIK, mockCalc)
+        assertTrue(calc.isFrameTransformationReachable(ft, links, jointLimits))
+
+        verifyOrder {
+            mockCalc.isFrameTransformationReachable(ft, links, any())
+            mockIK.solveChain(links, any(), jointLimits, ft)
+        }
+
+        confirmVerified(mockCalc, mockIK)
+    }
+
+    @Test
+    fun `calc returns false`() {
+        val ft = randomFrameTransformation()
+        val links = seaArmLinks
+        val jointLimits = links.map { JointLimits.NoLimit }
+
+        val mockCalc = mockk<LengthBasedReachabilityCalculator> {
+            every { isFrameTransformationReachable(ft, links, any()) } returns false
+        }
+
+        val mockIK = mockk<InverseKinematicsSolver> {}
+
+        val calc = LengthAndIKBasedReachabilityCalculator(mockIK, mockCalc)
+        assertFalse(calc.isFrameTransformationReachable(ft, links, jointLimits))
+
+        verifyOrder {
+            mockCalc.isFrameTransformationReachable(ft, links, any())
+        }
+
+        confirmVerified(mockCalc, mockIK)
+    }
+
+    @Test
+    fun `ik blows up`() {
+        val ft = randomFrameTransformation()
+        val links = seaArmLinks
+        val jointLimits = links.map { JointLimits.NoLimit }
+
+        val mockCalc = mockk<LengthBasedReachabilityCalculator> {
+            every { isFrameTransformationReachable(ft, links, any()) } returns true
+        }
+
+        val mockIK = mockk<InverseKinematicsSolver> {
+            every { solveChain(links, any(), jointLimits, ft) } throws IllegalStateException()
+        }
+
+        val calc = LengthAndIKBasedReachabilityCalculator(mockIK, mockCalc)
+        assertFalse(calc.isFrameTransformationReachable(ft, links, jointLimits))
+
+        verifyOrder {
+            mockCalc.isFrameTransformationReachable(ft, links, any())
+            mockIK.solveChain(links, any(), jointLimits, ft)
+        }
+
+        confirmVerified(mockCalc, mockIK)
+    }
+}

--- a/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthBasedReachabilityCalculatorTest.kt
+++ b/bowler-kernel/kinematics/src/test/kotlin/com/neuronrobotics/bowlerkernel/kinematics/motion/LengthBasedReachabilityCalculatorTest.kt
@@ -20,6 +20,7 @@ import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DefaultLink
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.DhParam
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.Link
 import com.neuronrobotics.bowlerkernel.kinematics.limb.link.LinkType
+import com.neuronrobotics.bowlerkernel.util.JointLimits
 import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -46,7 +47,13 @@ internal class LengthBasedReachabilityCalculatorTest {
         // solver isn't meant to catch this case
         val target = FrameTransformation.fromTranslation(10, 0, 0)
 
-        assertTrue(calculator.isFrameTransformationReachable(target, links))
+        assertTrue(
+            calculator.isFrameTransformationReachable(
+                target,
+                links,
+                listOf(JointLimits.NoLimit)
+            )
+        )
     }
 
     @Test
@@ -61,7 +68,13 @@ internal class LengthBasedReachabilityCalculatorTest {
 
         val target = FrameTransformation.fromTranslation(10, 0, 0)
 
-        assertTrue(calculator.isFrameTransformationReachable(target, links))
+        assertTrue(
+            calculator.isFrameTransformationReachable(
+                target,
+                links,
+                listOf(JointLimits.NoLimit)
+            )
+        )
     }
 
     @Test
@@ -76,6 +89,12 @@ internal class LengthBasedReachabilityCalculatorTest {
 
         val target = FrameTransformation.fromTranslation(15, 0, 0)
 
-        assertFalse(calculator.isFrameTransformationReachable(target, links))
+        assertFalse(
+            calculator.isFrameTransformationReachable(
+                target,
+                links,
+                listOf(JointLimits.NoLimit)
+            )
+        )
     }
 }

--- a/bowler-kernel/util/src/main/kotlin/com/neuronrobotics/bowlerkernel/util/JointLimits.kt
+++ b/bowler-kernel/util/src/main/kotlin/com/neuronrobotics/bowlerkernel/util/JointLimits.kt
@@ -33,4 +33,12 @@ data class JointLimits(
             "Maximum ($maximum) was less than minimum ($minimum)."
         }
     }
+
+    companion object {
+
+        /**
+         * An unconstrained joint.
+         */
+        val NoLimit = JointLimits(180, -180)
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,3 +45,4 @@ mockk.version=1.9.3
 java-bowler.version=3.26.2
 bowler-kinematics-native.partial-version=0.2.1
 jgit.version=5.4.0.201906121030-r
+mockk.version=1.9.3


### PR DESCRIPTION
### Description of the Change

This PR adds a joint limits parameter to `ReachabilityCalculator`. This PR also adds a new `ReachabilityCalculator` implementation: `LengthAndIKBasedReachabilityCalculator`.

### Motivation

Some `ReachabilityCalculator` implementations need to use IK, which needs joint limits.

### Possible Drawbacks

None.

### Verification Process

Unit tests.

### Applicable Issues

None.
