### PR TITLE
Prevent adding the same resourceid to the rpc twice

### DIFF
--- a/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/DefaultBowlerRPCProtocolReadGroupTest.kt
+++ b/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/DefaultBowlerRPCProtocolReadGroupTest.kt
@@ -484,6 +484,23 @@ internal class DefaultBowlerRPCProtocolReadGroupTest {
         }
     }
 
+    @Test
+    fun `add a read group twice`() {
+        setupReadGroup()
+
+        protocolTest(protocol, server) {
+            operation {
+                val result = it.addReadGroup(immutableSetOf(lineSensor1, lineSensor2)).attempt()
+                    .unsafeRunSync()
+                assertTrue(result.isLeft())
+            } pcSends {
+                immutableListOf()
+            } deviceResponds {
+                immutableListOf()
+            }
+        }
+    }
+
     private fun setupReadGroup() =
         setupReadGroupImpl { addReadGroup(immutableSetOf(lineSensor1, lineSensor2)) }
 

--- a/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/DefaultBowlerRPCProtocolReadTest.kt
+++ b/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/DefaultBowlerRPCProtocolReadTest.kt
@@ -164,6 +164,22 @@ internal class DefaultBowlerRPCProtocolReadTest {
         }
     }
 
+    @Test
+    fun `add resource more than once`() {
+        setupRead(lineSensor)
+
+        protocolTest(protocol, server) {
+            operation {
+                val result = it.addRead(lineSensor).attempt().unsafeRunSync()
+                assertTrue(result.isLeft())
+            } pcSends {
+                immutableListOf()
+            } deviceResponds {
+                immutableListOf()
+            }
+        }
+    }
+
     private fun setupRead(resourceId: ResourceId) =
         setupReadImpl(resourceId) { addRead(resourceId) }
 

--- a/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/DefaultBowlerRPCProtocolWriteGroupTest.kt
+++ b/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/DefaultBowlerRPCProtocolWriteGroupTest.kt
@@ -181,12 +181,14 @@ internal class DefaultBowlerRPCProtocolWriteGroupTest {
                 assertTrue(result.isLeft())
             } pcSends {
                 immutableListOf(
-                    getPayload(DefaultBowlerRPCProtocol.PAYLOAD_SIZE, byteArrayOf(
+                    getPayload(
+                        DefaultBowlerRPCProtocol.PAYLOAD_SIZE, byteArrayOf(
                             DefaultBowlerRPCProtocol.OPERATION_GROUP_DISCOVERY_ID,
                             1,
                             DefaultBowlerRPCProtocol.DEFAULT_START_PACKET_ID,
                             2
-                        ))
+                        )
+                    )
                 )
             } deviceResponds {
                 immutableListOf(
@@ -207,19 +209,41 @@ internal class DefaultBowlerRPCProtocolWriteGroupTest {
                 assertTrue(result.isLeft())
             } pcSends {
                 immutableListOf(
-                    getPayload(DefaultBowlerRPCProtocol.PAYLOAD_SIZE, byteArrayOf(
+                    getPayload(
+                        DefaultBowlerRPCProtocol.PAYLOAD_SIZE, byteArrayOf(
                             DefaultBowlerRPCProtocol.OPERATION_GROUP_DISCOVERY_ID,
                             1,
                             DefaultBowlerRPCProtocol.DEFAULT_START_PACKET_ID,
                             2
-                        )),
-                    getPayload(
-                        DefaultBowlerRPCProtocol.PAYLOAD_SIZE,
-                        byteArrayOf(DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID, 1, 0, 1, 0, 0, 2, 1, 32)
+                        )
                     ),
                     getPayload(
                         DefaultBowlerRPCProtocol.PAYLOAD_SIZE,
-                        byteArrayOf(DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID, 1, 1, 2, 0, 0, 2, 1, 33)
+                        byteArrayOf(
+                            DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID,
+                            1,
+                            0,
+                            1,
+                            0,
+                            0,
+                            2,
+                            1,
+                            32
+                        )
+                    ),
+                    getPayload(
+                        DefaultBowlerRPCProtocol.PAYLOAD_SIZE,
+                        byteArrayOf(
+                            DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID,
+                            1,
+                            1,
+                            2,
+                            0,
+                            0,
+                            2,
+                            1,
+                            33
+                        )
                     )
                 )
             } deviceResponds {
@@ -249,16 +273,28 @@ internal class DefaultBowlerRPCProtocolWriteGroupTest {
                 assertTrue(result.isLeft())
             } pcSends {
                 immutableListOf(
-                    getPayload(DefaultBowlerRPCProtocol.PAYLOAD_SIZE, byteArrayOf(
+                    getPayload(
+                        DefaultBowlerRPCProtocol.PAYLOAD_SIZE, byteArrayOf(
                             DefaultBowlerRPCProtocol.OPERATION_GROUP_DISCOVERY_ID,
                             1,
                             DefaultBowlerRPCProtocol.DEFAULT_START_PACKET_ID,
                             2
-                        )),
+                        )
+                    ),
                     // This one failing means that led2 should not be discovered
                     getPayload(
                         DefaultBowlerRPCProtocol.PAYLOAD_SIZE,
-                        byteArrayOf(DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID, 1, 0, 1, 0, 0, 2, 1, 32)
+                        byteArrayOf(
+                            DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID,
+                            1,
+                            0,
+                            1,
+                            0,
+                            0,
+                            2,
+                            1,
+                            32
+                        )
                     )
                 )
             } deviceResponds {
@@ -294,19 +330,41 @@ internal class DefaultBowlerRPCProtocolWriteGroupTest {
                 assertTrue(result.isRight())
             } pcSends {
                 immutableListOf(
-                    getPayload(DefaultBowlerRPCProtocol.PAYLOAD_SIZE, byteArrayOf(
+                    getPayload(
+                        DefaultBowlerRPCProtocol.PAYLOAD_SIZE, byteArrayOf(
                             DefaultBowlerRPCProtocol.OPERATION_GROUP_DISCOVERY_ID,
                             1,
                             DefaultBowlerRPCProtocol.DEFAULT_START_PACKET_ID,
                             2
-                        )),
-                    getPayload(
-                        DefaultBowlerRPCProtocol.PAYLOAD_SIZE,
-                        byteArrayOf(DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID, 1, 0, 1, 0, 0, 2, 1, 7)
+                        )
                     ),
                     getPayload(
                         DefaultBowlerRPCProtocol.PAYLOAD_SIZE,
-                        byteArrayOf(DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID, 1, 1, 2, 0, 0, 2, 1, 8)
+                        byteArrayOf(
+                            DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID,
+                            1,
+                            0,
+                            1,
+                            0,
+                            0,
+                            2,
+                            1,
+                            7
+                        )
+                    ),
+                    getPayload(
+                        DefaultBowlerRPCProtocol.PAYLOAD_SIZE,
+                        byteArrayOf(
+                            DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID,
+                            1,
+                            1,
+                            2,
+                            0,
+                            0,
+                            2,
+                            1,
+                            8
+                        )
                     )
                 )
             } deviceResponds {
@@ -367,19 +425,41 @@ internal class DefaultBowlerRPCProtocolWriteGroupTest {
                 assertTrue(result.isRight())
             } pcSends {
                 immutableListOf(
-                    getPayload(DefaultBowlerRPCProtocol.PAYLOAD_SIZE, byteArrayOf(
+                    getPayload(
+                        DefaultBowlerRPCProtocol.PAYLOAD_SIZE, byteArrayOf(
                             DefaultBowlerRPCProtocol.OPERATION_GROUP_DISCOVERY_ID,
                             1,
                             DefaultBowlerRPCProtocol.DEFAULT_START_PACKET_ID,
                             2
-                        )),
-                    getPayload(
-                        DefaultBowlerRPCProtocol.PAYLOAD_SIZE,
-                        byteArrayOf(DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID, 1, 0, 1, 0, 0, 2, 1, 7)
+                        )
                     ),
                     getPayload(
                         DefaultBowlerRPCProtocol.PAYLOAD_SIZE,
-                        byteArrayOf(DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID, 1, 1, 2, 0, 0, 2, 1, 8)
+                        byteArrayOf(
+                            DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID,
+                            1,
+                            0,
+                            1,
+                            0,
+                            0,
+                            2,
+                            1,
+                            7
+                        )
+                    ),
+                    getPayload(
+                        DefaultBowlerRPCProtocol.PAYLOAD_SIZE,
+                        byteArrayOf(
+                            DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID,
+                            1,
+                            1,
+                            2,
+                            0,
+                            0,
+                            2,
+                            1,
+                            8
+                        )
                     )
                 )
             } deviceResponds {
@@ -425,6 +505,22 @@ internal class DefaultBowlerRPCProtocolWriteGroupTest {
         }
     }
 
+    @Test
+    fun `add a write group twice`() {
+        setupWriteGroup()
+
+        protocolTest(protocol, server) {
+            operation {
+                val result = it.addWriteGroup(immutableSetOf(led1, led2)).attempt().unsafeRunSync()
+                assertTrue(result.isLeft())
+            } pcSends {
+                immutableListOf()
+            } deviceResponds {
+                immutableListOf()
+            }
+        }
+    }
+
     private fun setupWriteGroup() {
         protocolTest(protocol, server) {
             operation {
@@ -432,19 +528,41 @@ internal class DefaultBowlerRPCProtocolWriteGroupTest {
                 assertTrue(result.isRight())
             } pcSends {
                 immutableListOf(
-                    getPayload(DefaultBowlerRPCProtocol.PAYLOAD_SIZE, byteArrayOf(
+                    getPayload(
+                        DefaultBowlerRPCProtocol.PAYLOAD_SIZE, byteArrayOf(
                             DefaultBowlerRPCProtocol.OPERATION_GROUP_DISCOVERY_ID,
                             1,
                             DefaultBowlerRPCProtocol.DEFAULT_START_PACKET_ID,
                             2
-                        )),
-                    getPayload(
-                        DefaultBowlerRPCProtocol.PAYLOAD_SIZE,
-                        byteArrayOf(DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID, 1, 0, 1, 0, 0, 2, 1, 32)
+                        )
                     ),
                     getPayload(
                         DefaultBowlerRPCProtocol.PAYLOAD_SIZE,
-                        byteArrayOf(DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID, 1, 1, 2, 0, 0, 2, 1, 33)
+                        byteArrayOf(
+                            DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID,
+                            1,
+                            0,
+                            1,
+                            0,
+                            0,
+                            2,
+                            1,
+                            32
+                        )
+                    ),
+                    getPayload(
+                        DefaultBowlerRPCProtocol.PAYLOAD_SIZE,
+                        byteArrayOf(
+                            DefaultBowlerRPCProtocol.OPERATION_GROUP_MEMBER_DISCOVERY_ID,
+                            1,
+                            1,
+                            2,
+                            0,
+                            0,
+                            2,
+                            1,
+                            33
+                        )
                     )
                 )
             } deviceResponds {

--- a/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/DefaultBowlerRPCProtocolWriteTest.kt
+++ b/bowler-kernel/hardware/src/test/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/DefaultBowlerRPCProtocolWriteTest.kt
@@ -205,6 +205,22 @@ internal class DefaultBowlerRPCProtocolWriteTest {
         }
     }
 
+    @Test
+    fun `add a write twice`() {
+        setupWrite()
+
+        protocolTest(protocol, server) {
+            operation {
+                val result = it.addWrite(led).attempt().unsafeRunSync()
+                assertTrue(result.isLeft())
+            } pcSends {
+                immutableListOf()
+            } deviceResponds {
+                immutableListOf()
+            }
+        }
+    }
+
     private fun setupWrite() {
         protocolTest(protocol, server) {
             operation {


### PR DESCRIPTION
### Description of the Change

This PR adds validation logic in the RPC to prevent adding the same resourceid more than once, in any configuration.

### Motivation

ResourceIds are meant to be unique. The "first line of defense" is the `BaseHardwareRegistry`, but the validation logic in there can be complicated and can miss cases. Adding additional validation logic at the RPC level ensures this constraint.

### Possible Drawbacks

None.

### Verification Process

New tests.

### Applicable Issues

Closes #56.
