### PR TITLE
Add RPC strerror

### DIFF
--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/BowlerRPCProtocol.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/BowlerRPCProtocol.kt
@@ -326,4 +326,12 @@ interface BowlerRPCProtocol {
      * @return The entire read payload.
      */
     fun genericWriteRead(resourcesAndValues: List<Pair<ResourceId, ByteArray>>): IO<List<ByteArray>>
+
+    /**
+     * Looks up the string representation of the [error] code.
+     *
+     * @param error The error code.
+     * @return The string equivalent.
+     */
+    fun strerror(error: Byte): String
 }

--- a/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/DefaultBowlerRPCProtocol.kt
+++ b/bowler-kernel/hardware/src/main/kotlin/com/neuronrobotics/bowlerkernel/hardware/protocol/DefaultBowlerRPCProtocol.kt
@@ -20,7 +20,9 @@ package com.neuronrobotics.bowlerkernel.hardware.protocol
 
 import arrow.core.Either
 import arrow.effects.IO
+import arrow.effects.IOOf
 import arrow.effects.extensions.io.monad.binding
+import arrow.effects.extensions.io.monad.flatten
 import arrow.effects.liftIO
 import com.google.common.collect.ImmutableSet
 import com.neuronrobotics.bowlerkernel.deviceserver.DeviceServer
@@ -101,7 +103,7 @@ open class DefaultBowlerRPCProtocol(
     private fun sendGeneralDiscoveryPacket(
         operation: Byte,
         payload: ByteArray
-    ): IO<ByteArray> {
+    ): IO<ByteArray> = IO {
         val payloadWithHeader = getPayload(PAYLOAD_SIZE, byteArrayOf(operation) + payload)
 
         LOGGER.debug {
@@ -111,7 +113,7 @@ open class DefaultBowlerRPCProtocol(
             """.trimMargin()
         }
 
-        return server.write(DISCOVERY_PACKET_ID, payloadWithHeader).map {
+        server.write(DISCOVERY_PACKET_ID, payloadWithHeader).map {
             LOGGER.debug {
                 """
                 |Discovery response:
@@ -121,7 +123,7 @@ open class DefaultBowlerRPCProtocol(
 
             it
         }
-    }
+    }.flatten()
 
     /**
      * Sends a discovery packet.
@@ -214,7 +216,7 @@ open class DefaultBowlerRPCProtocol(
      */
     private fun addGroup(
         resourceIds: ImmutableSet<ResourceId>
-    ): IO<Unit> {
+    ): IO<Unit> = IO {
         LOGGER.debug {
             """
             |Adding group:
@@ -233,93 +235,85 @@ open class DefaultBowlerRPCProtocol(
             count.toByte()
         )
 
-        return groupStatus.flatMap {
-            if (it[0] == STATUS_ACCEPTED) {
-                groupIdToPacketId[groupId] = packetId
-                groupIdToCount[groupId] = count
+        groupStatus.ifAccepted {
+            groupIdToPacketId[groupId] = packetId
+            groupIdToCount[groupId] = count
 
-                var currentSendIndex = 0.toByte()
-                var currentReceiveIndex = 0.toByte()
+            var currentSendIndex = 0.toByte()
+            var currentReceiveIndex = 0.toByte()
 
-                val allResources = binding {
-                    resourceIds.forEach { resourceId ->
-                        val sendLength = resourceId.resourceType.sendLength
-                        val receiveLength = resourceId.resourceType.receiveLength
+            val allResources = binding {
+                resourceIds.forEach { resourceId ->
+                    val sendLength = resourceId.resourceType.sendLength
+                    val receiveLength = resourceId.resourceType.receiveLength
 
-                        if (isGreaterThanUnsignedByte(currentSendIndex + sendLength) ||
-                            isGreaterThanUnsignedByte(currentReceiveIndex + receiveLength)
-                        ) {
-                            IO.raiseError<Unit>(
-                                IllegalStateException(
-                                    """
-                                    |Cannot handle payload indices greater than a byte.
-                                    |Send index: $currentSendIndex
-                                    |Receive index: $currentReceiveIndex
-                                    """.trimMargin()
-                                )
-                            ).bind()
-                        }
-
-                        if (currentSendIndex + sendLength > PAYLOAD_SIZE ||
-                            currentReceiveIndex + receiveLength > PAYLOAD_SIZE
-                        ) {
-                            IO.raiseError<Unit>(
-                                IllegalStateException(
-                                    """
-                                    |Cannot handle payload indices greater than the payload size.
-                                    |Payload size: $PAYLOAD_SIZE
-                                    |Send index: $currentSendIndex
-                                    |Receive index: $currentReceiveIndex
-                                    """.trimMargin()
-                                )
-                            ).bind()
-                        }
-
-                        val sendStart = currentSendIndex
-                        val sendEnd = (currentSendIndex + sendLength).toByte()
-                        val receiveStart = currentReceiveIndex
-                        val receiveEnd = (currentReceiveIndex + receiveLength).toByte()
-
-                        sendGroupMemberDiscoveryPacket(
-                            groupId.toByte(),
-                            sendStart,
-                            sendEnd,
-                            receiveStart,
-                            receiveEnd,
-                            resourceId.resourceType.type,
-                            resourceId.attachmentPoint.type,
-                            resourceId.attachmentPoint.data
-                        ).flatMap {
-                            if (it[0] == STATUS_ACCEPTED) {
-                                groupedResourceToGroupId[resourceId] = groupId
-                                groupIdToMembers.getOrPut(groupId) {
-                                    mutableSetOf()
-                                }.add(resourceId)
-                                groupMemberToSendRange[resourceId] = sendStart to sendEnd
-                                groupMemberToReceiveRange[resourceId] = receiveStart to receiveEnd
-
-                                currentSendIndex = (currentSendIndex + sendLength).toByte()
-                                currentReceiveIndex = (currentReceiveIndex + receiveLength).toByte()
-
-                                IO.just(Unit)
-                            } else {
-                                IO.raiseError(UnsupportedOperationException(it.joinToString()))
-                            }
-                        }.bind()
+                    if (isGreaterThanUnsignedByte(currentSendIndex + sendLength) ||
+                        isGreaterThanUnsignedByte(currentReceiveIndex + receiveLength)
+                    ) {
+                        IO.raiseError<Unit>(
+                            IllegalStateException(
+                                """
+                                |Cannot handle payload indices greater than a byte.
+                                |Send index: $currentSendIndex
+                                |Receive index: $currentReceiveIndex
+                                """.trimMargin()
+                            )
+                        ).bind()
                     }
-                }
 
-                allResources.flatMap {
-                    IO {
-                        // TODO: Expose maxRetries
-                        server.addUnreliable(packetId.toByte(), 10)
+                    if (currentSendIndex + sendLength > PAYLOAD_SIZE ||
+                        currentReceiveIndex + receiveLength > PAYLOAD_SIZE
+                    ) {
+                        IO.raiseError<Unit>(
+                            IllegalStateException(
+                                """
+                                |Cannot handle payload indices greater than the payload size.
+                                |Payload size: $PAYLOAD_SIZE
+                                |Send index: $currentSendIndex
+                                |Receive index: $currentReceiveIndex
+                                """.trimMargin()
+                            )
+                        ).bind()
                     }
+
+                    val sendStart = currentSendIndex
+                    val sendEnd = (currentSendIndex + sendLength).toByte()
+                    val receiveStart = currentReceiveIndex
+                    val receiveEnd = (currentReceiveIndex + receiveLength).toByte()
+
+                    sendGroupMemberDiscoveryPacket(
+                        groupId.toByte(),
+                        sendStart,
+                        sendEnd,
+                        receiveStart,
+                        receiveEnd,
+                        resourceId.resourceType.type,
+                        resourceId.attachmentPoint.type,
+                        resourceId.attachmentPoint.data
+                    ).ifAccepted {
+                        groupedResourceToGroupId[resourceId] = groupId
+                        groupIdToMembers.getOrPut(groupId) {
+                            mutableSetOf()
+                        }.add(resourceId)
+                        groupMemberToSendRange[resourceId] = sendStart to sendEnd
+                        groupMemberToReceiveRange[resourceId] = receiveStart to receiveEnd
+
+                        currentSendIndex = (currentSendIndex + sendLength).toByte()
+                        currentReceiveIndex = (currentReceiveIndex + receiveLength).toByte()
+
+                        IO.just(Unit)
+                    }.bind()
                 }
-            } else {
-                IO.raiseError(UnsupportedOperationException(it.joinToString()))
+            }
+
+            allResources.flatMap {
+                IO {
+                    // TODO: Expose maxRetries
+                    server.addUnreliable(packetId.toByte(), 10)
+                }
             }
         }
-    }
+    }.flatten()
 
     /**
      * Adds a non-polling resource by sending a discovery packet.
@@ -328,7 +322,7 @@ open class DefaultBowlerRPCProtocol(
      */
     private fun addResource(
         resourceId: ResourceId
-    ): IO<Unit> {
+    ): IO<Unit> = IO {
         LOGGER.debug {
             """
             |Adding resource:
@@ -345,20 +339,16 @@ open class DefaultBowlerRPCProtocol(
             resourceId.attachmentPoint.data
         )
 
-        return status.flatMap {
-            if (it[0] == STATUS_ACCEPTED) {
+        status.ifAccepted {
+            IO {
                 // Discovery packet was accepted
                 nonGroupedResourceIdToPacketId[resourceId] = packetId
 
-                IO {
-                    // TODO: Expose maxRetries
-                    server.addUnreliable(packetId.toByte(), 10)
-                }
-            } else {
-                IO.raiseError(UnsupportedOperationException(it.joinToString()))
+                // TODO: Expose maxRetries
+                server.addUnreliable(packetId.toByte(), 10)
             }
         }
-    }
+    }.flatten()
 
     /**
      * Computes the next packet id and validates that it can be sent to the device.
@@ -396,8 +386,8 @@ open class DefaultBowlerRPCProtocol(
      */
     private fun <T> validateGroupSendResources(
         resourcesAndValues: List<Pair<ResourceId, T>>
-    ): IO<Int> {
-        return getValidatedGroupId(resourcesAndValues.first().first).flatMap { groupId ->
+    ): IO<Int> = IO {
+        getValidatedGroupId(resourcesAndValues.first().first).flatMap { groupId ->
             if (resourcesAndValues.size != groupIdToCount[groupId]) {
                 return@flatMap IO.raiseError<Int>(
                     UnsupportedOperationException("Mismatched group size.")
@@ -419,7 +409,7 @@ open class DefaultBowlerRPCProtocol(
 
             IO.just(groupId)
         }
-    }
+    }.flatten()
 
     /**
      * Validates that all resources are part of the same group, there are the correct number of
@@ -429,8 +419,8 @@ open class DefaultBowlerRPCProtocol(
      * @param resourceIds The group members.
      * @return The group id.
      */
-    private fun validateGroupReceiveResources(resourceIds: List<ResourceId>): IO<Int> {
-        return getValidatedGroupId(resourceIds.first()).flatMap { groupId ->
+    private fun validateGroupReceiveResources(resourceIds: List<ResourceId>): IO<Int> = IO {
+        getValidatedGroupId(resourceIds.first()).flatMap { groupId ->
             if (resourceIds.size != groupIdToCount[groupId]) {
                 return@flatMap IO.raiseError<Int>(
                     UnsupportedOperationException("Mismatched group size.")
@@ -451,7 +441,7 @@ open class DefaultBowlerRPCProtocol(
 
             IO.just(groupId)
         }
-    }
+    }.flatten()
 
     /**
      * Maps the [resourceId] to its group id with validation.
@@ -529,9 +519,10 @@ open class DefaultBowlerRPCProtocol(
     protected fun <T> handleRead(
         resourceId: ResourceId,
         parseReceivePayload: ParseReceivePayload<T>
-    ): IO<T> {
-        val packetId = getValidatedPacketId(resourceId)
-        return server.write(packetId.toByte(), ByteArray(PAYLOAD_SIZE) { 0 }).map {
+    ): IO<T> = IO {
+        getValidatedPacketId(resourceId)
+    }.flatMap { packetId ->
+        server.write(packetId.toByte(), ByteArray(PAYLOAD_SIZE) { 0 }).map {
             parseReceivePayload(it, 0, it.size)
         }
     }
@@ -551,16 +542,14 @@ open class DefaultBowlerRPCProtocol(
     protected fun <T> handleGroupRead(
         resourceIds: List<ResourceId>,
         parseReceivePayload: ParseReceivePayload<T>
-    ): IO<List<T>> {
-        return validateGroupReceiveResources(resourceIds).flatMap { groupId ->
-            val packetId = groupIdToPacketId[groupId]!!
-            server.write(packetId.toByte(), ByteArray(PAYLOAD_SIZE) { 0 }).map {
-                parseGroupReceivePayload(
-                    resourceIds,
-                    it,
-                    parseReceivePayload
-                )
-            }
+    ): IO<List<T>> = validateGroupReceiveResources(resourceIds).flatMap { groupId ->
+        val packetId = groupIdToPacketId[groupId]!!
+        server.write(packetId.toByte(), ByteArray(PAYLOAD_SIZE) { 0 }).map {
+            parseGroupReceivePayload(
+                resourceIds,
+                it,
+                parseReceivePayload
+            )
         }
     }
 
@@ -578,9 +567,10 @@ open class DefaultBowlerRPCProtocol(
         resourceId: ResourceId,
         value: S,
         makeSendPayload: (S) -> ByteArray
-    ): IO<Unit> {
-        val packetId = getValidatedPacketId(resourceId)
-        return server.write(packetId.toByte(), getPayload(PAYLOAD_SIZE, makeSendPayload(value)))
+    ): IO<Unit> = IO {
+        getValidatedPacketId(resourceId)
+    }.flatMap { packetId ->
+        server.write(packetId.toByte(), getPayload(PAYLOAD_SIZE, makeSendPayload(value)))
             .map { Unit }
     }
 
@@ -601,9 +591,10 @@ open class DefaultBowlerRPCProtocol(
         value: S,
         makeSendPayload: (S) -> ByteArray,
         parseReceivePayload: ParseReceivePayload<R>
-    ): IO<R> {
-        val packetId = getValidatedPacketId(resourceId)
-        return server.write(packetId.toByte(), getPayload(PAYLOAD_SIZE, makeSendPayload(value)))
+    ): IO<R> = IO {
+        getValidatedPacketId(resourceId)
+    }.flatMap { packetId ->
+        server.write(packetId.toByte(), getPayload(PAYLOAD_SIZE, makeSendPayload(value)))
             .map {
                 parseReceivePayload(it, 0, it.size)
             }
@@ -615,14 +606,13 @@ open class DefaultBowlerRPCProtocol(
      * @param resourceId The resource id.
      * @return The packet id.
      */
-    private fun getValidatedPacketId(resourceId: ResourceId): Int {
-        return nonGroupedResourceIdToPacketId[resourceId] ?: throw IllegalArgumentException(
+    private fun getValidatedPacketId(resourceId: ResourceId) =
+        nonGroupedResourceIdToPacketId[resourceId] ?: throw IllegalArgumentException(
             """
             |The resource id was not discovered:
             |$resourceId
             """.trimMargin()
         )
-    }
 
     /**
      * Performs a full RPC group write call:
@@ -638,14 +628,12 @@ open class DefaultBowlerRPCProtocol(
     protected fun <T> handleGroupWrite(
         resourcesAndValues: List<Pair<ResourceId, T>>,
         makeSendPayload: (T) -> ByteArray
-    ): IO<Unit> {
-        return validateGroupSendResources(resourcesAndValues).flatMap { groupId ->
-            val packetId = groupIdToPacketId[groupId]!!
-            server.write(
-                packetId.toByte(),
-                getPayload(PAYLOAD_SIZE, makeGroupSendPayload(resourcesAndValues, makeSendPayload))
-            ).map { Unit }
-        }
+    ): IO<Unit> = validateGroupSendResources(resourcesAndValues).flatMap { groupId ->
+        val packetId = groupIdToPacketId[groupId]!!
+        server.write(
+            packetId.toByte(),
+            getPayload(PAYLOAD_SIZE, makeGroupSendPayload(resourcesAndValues, makeSendPayload))
+        ).map { Unit }
     }
 
     /**
@@ -666,21 +654,35 @@ open class DefaultBowlerRPCProtocol(
         resourcesAndValues: List<Pair<ResourceId, T>>,
         makeSendPayload: (T) -> ByteArray,
         parseReceivePayload: ParseReceivePayload<R>
-    ): IO<List<R>> {
-        return validateGroupSendResources(resourcesAndValues).flatMap { groupId ->
-            val packetId = groupIdToPacketId[groupId]!!
-            server.write(
-                packetId.toByte(),
-                getPayload(PAYLOAD_SIZE, makeGroupSendPayload(resourcesAndValues, makeSendPayload))
-            ).map {
-                parseGroupReceivePayload(
-                    resourcesAndValues.map { it.first },
-                    it,
-                    parseReceivePayload
+    ): IO<List<R>> = validateGroupSendResources(resourcesAndValues).flatMap { groupId ->
+        val packetId = groupIdToPacketId[groupId]!!
+        server.write(
+            packetId.toByte(),
+            getPayload(PAYLOAD_SIZE, makeGroupSendPayload(resourcesAndValues, makeSendPayload))
+        ).map {
+            parseGroupReceivePayload(
+                resourcesAndValues.map { it.first },
+                it,
+                parseReceivePayload
+            )
+        }
+    }
+
+    /**
+     * Flatmaps over [this] with [f] if the payload was accepted. Errors otherwise.
+     */
+    protected fun <A> IO<ByteArray>.ifAccepted(f: (ByteArray) -> IOOf<A>): IO<A> =
+        flatMap {
+            if (it[0] == STATUS_ACCEPTED) {
+                f(it)
+            } else {
+                IO.raiseError(
+                    UnsupportedOperationException(
+                        "${strerror(it[0])}\n${it.joinToString()}"
+                    )
                 )
             }
         }
-    }
 
     override fun connect() = server.connect().map {
         server.addReliable(DISCOVERY_PACKET_ID)
@@ -998,6 +1000,22 @@ open class DefaultBowlerRPCProtocol(
             this::makeGenericWritePayload,
             this::parseGenericReadPayload
         )
+
+    override fun strerror(error: Byte) = when (error) {
+        STATUS_ACCEPTED -> "Payload accepted."
+        STATUS_REJECTED_GENERIC -> "Generic payload rejection."
+        STATUS_REJECTED_UNKNOWN_RESOURCE -> "Unknown resource."
+        STATUS_REJECTED_UNKNOWN_ATTACHMENT -> "Unknown attachment."
+        STATUS_REJECTED_INVALID_ATTACHMENT -> "Invalid attachment."
+        STATUS_REJECTED_INVALID_ATTACHMENT_DATA -> "Invalid attachment data."
+        STATUS_REJECTED_INVALID_GROUP_ID -> "Invalid group id."
+        STATUS_REJECTED_GROUP_FULL -> "Group full."
+        STATUS_REJECTED_UNKNOWN_OPERATION -> "Unknown operation."
+        STATUS_DISCARD_IN_PROGRESS -> "Discard in progress."
+        STATUS_DISCARD_COMPLETE -> "Discard complete."
+        STATUS_REJECTED_INVALID_PACKET_ID -> "Invalid packet id."
+        else -> "Unknown error."
+    }
 
     /**
      * The lowest packet id.


### PR DESCRIPTION
### Description of the Change

This PR adds `BowlerRPCProtocol.strerror(error: Byte): String`, which mirrors C's `strerror`.

### Motivation

Error codes should be more human-readable.

### Possible Drawbacks

None.

### Verification Process

This was not verified because it's mostly a logging change.

### Applicable Issues

Closes #59.
