### PR TITLE
Add a test to assert script classpath isolation

### DIFF
--- a/scripthost/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/scripthost/Session.kt
+++ b/scripthost/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/scripthost/Session.kt
@@ -49,6 +49,7 @@ import kotlinx.coroutines.selects.select
 import mu.KotlinLogging
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.coroutines.coroutineContext
 import kotlin.time.ExperimentalTime
@@ -230,7 +231,7 @@ class Session(
         ) {
             logger.debug { "requestId=${runRequest.requestId} Starting script." }
             script.start(emptyList(), null)
-            val scriptResult = script.join()
+            val scriptResult = script.join(0, 1000, TimeUnit.MILLISECONDS)
             logger.info { "requestId=${runRequest.requestId} Script returned:\n$scriptResult" }
             when (scriptResult) {
                 // Throw when the script errored so that the task and request fail

--- a/scripting/build.gradle.kts
+++ b/scripting/build.gradle.kts
@@ -5,7 +5,7 @@ dependencies {
     implementation(project(":hardware"))
     implementation(project(":protoutil"))
 
-    implementation(group = "org.codehaus.groovy", name = "groovy", version = Versions.groovy)
+    implementation(group = "org.codehaus.groovy", name = "groovy-all", version = Versions.groovy)
     implementation(group = "org.apache.ivy", name = "ivy", version = Versions.ivy)
     implementation(group = "io.arrow-kt", name = "arrow-core", version = Versions.arrow)
     implementation(group = "io.arrow-kt", name = "arrow-syntax", version = Versions.arrow)

--- a/scripting/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/scripting/DefaultScript.kt
+++ b/scripting/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/scripting/DefaultScript.kt
@@ -66,6 +66,8 @@ class DefaultScript(
         returnValue = executor.submit(scriptClosure.partially1(args).partially1(this))
     }
 
+    override fun join() = join(0, 1000, TimeUnit.MILLISECONDS)
+
     override fun join(scriptTimeout: Long, threadTimeout: Long, timeUnit: TimeUnit): Either<Throwable, Any?> {
         // Get the result. `get` will throw an ExecutionException if the script threw an exception.
         // This suppression is fine because we treat the exception carefully and propagate it to the user.
@@ -109,6 +111,6 @@ class DefaultScript(
         threads.add(thread)
     }
 
-    override fun resolveAndLoad(fileSpec: FileSpec, scriptEnvironment: Map<String, String>) =
-        scriptLoader.resolveAndLoad(fileSpec, listOf(), scriptEnvironment)
+    override fun startChildScript(fileSpec: FileSpec, scriptEnvironment: Map<String, String>, args: List<Any?>) =
+        scriptLoader.resolveAndLoad(fileSpec, listOf(), scriptEnvironment).also { it.start(args, this) }
 }

--- a/scripting/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/scripting/Script.kt
+++ b/scripting/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/scripting/Script.kt
@@ -42,6 +42,15 @@ interface Script {
 
     /**
      * Wait for this script to finish and return its result as an [Either.Right]. If the script threw a non-fatal
+     * exception, that exception is returned as an [Either.Left] instead. See the [join] docs for more comprehensive
+     * documentation.
+     *
+     * @return The result of the script or an error.
+     */
+    fun join(): Either<Throwable, Any?>
+
+    /**
+     * Wait for this script to finish and return its result as an [Either.Right]. If the script threw a non-fatal
      * exception, that exception is returned as an [Either.Left] instead.
      *
      * A script is finished when its thread and all of its child threads have been joined. After a script has been
@@ -51,14 +60,15 @@ interface Script {
      * out and interrupted after the [threadTimeout].
      *
      * @param scriptTimeout The maximum amount of time the script can run for. A value of zero means to wait forever.
+     * Zero by default.
      * @param threadTimeout The maximum amount of time the script's child threads can each run for. A value of zero
-     * means to wait forever.
-     * @param timeUnit The unit of the timeouts.
+     * means to wait forever. 1000 by default.
+     * @param timeUnit The unit of the timeouts. [TimeUnit.MILLISECONDS] by default.
      * @return The result of the script or an error.
      */
     fun join(
-        scriptTimeout: Long = 0,
-        threadTimeout: Long = 1000,
-        timeUnit: TimeUnit = TimeUnit.MILLISECONDS
+        scriptTimeout: Long,
+        threadTimeout: Long,
+        timeUnit: TimeUnit
     ): Either<Throwable, Any?>
 }

--- a/scripting/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/scripting/ScriptExecutionEnvironment.kt
+++ b/scripting/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/scripting/ScriptExecutionEnvironment.kt
@@ -23,6 +23,11 @@ import com.commonwealthrobotics.proto.gitfs.FileSpec
  * This "execution environment" provides all the facilities a script needs to interact with the Bowler stack. Scripts
  * should not interact with any other part of the Bowler stack directly; all interaction should go through this
  * interface.
+ *
+ * There are three injected variables in Groovy scripts:
+ * 1. `args`: The argument passes to the script.
+ * 2. `scriptEnvironment`: The script environment map.
+ * 3. `scriptExecutionEnvironment`: The script-local execution environment.
  */
 interface ScriptExecutionEnvironment {
 

--- a/scripting/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/scripting/ScriptExecutionEnvironment.kt
+++ b/scripting/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/scripting/ScriptExecutionEnvironment.kt
@@ -40,7 +40,8 @@ interface ScriptExecutionEnvironment {
      *
      * @param fileSpec The script to run.
      * @param scriptEnvironment The environment to pass to the script.
-     * @return A runnable script.
+     * @param args The arguments to pass to the script.
+     * @return A started script.
      */
-    fun resolveAndLoad(fileSpec: FileSpec, scriptEnvironment: Map<String, String>): Script
+    fun startChildScript(fileSpec: FileSpec, scriptEnvironment: Map<String, String>, args: List<Any?>): Script
 }

--- a/scripting/src/test/kotlin/com/commonwealthrobotics/bowlerkernel/scripting/ScriptClasspathIsolationIntegTest.kt
+++ b/scripting/src/test/kotlin/com/commonwealthrobotics/bowlerkernel/scripting/ScriptClasspathIsolationIntegTest.kt
@@ -1,0 +1,168 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.commonwealthrobotics.bowlerkernel.scripting
+
+import com.commonwealthrobotics.proto.gitfs.FileSpec
+import com.google.protobuf.ByteString
+import io.kotest.assertions.arrow.either.shouldBeLeft
+import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * This class is meant to test classpath isolation between scripts. There are two primary requirements:
+ * 1. A dependency of one script (added via Grapes) must not be visible to other scripts. This means that if a script A
+ *      has a dependency on class Foo, another script B, that is not a child of A, must not be able to load class Foo
+ *      without also declaring a dependency on it.
+ * 2. Following from (1), two scripts must be able to declare different versions of the same dependency without
+ *      conflict. This means that if a script A has a dependency on version 1.0 of class Foo, another script B, that is
+ *      not a child of A, must be able to declare a dependency on a different version of Foo and load that version (not
+ *      A's version of Foo).
+ */
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+internal class ScriptClasspathIsolationIntegTest {
+
+    @Test
+    fun `requirement 1`(@TempDir tempDir: File) {
+        // We create one script that grabs and loads a dependency (and returns an instance of it to ensure that grapes
+        // work).
+        val scriptWithDepFile = createTempFile(suffix = ".groovy", directory = tempDir)
+        scriptWithDepFile.writeText(
+            """
+            @Grapes(@Grab(group = 'commons-cli', module = 'commons-cli', version = '1.4'))
+            import org.apache.commons.cli.Options;
+            return new Options()
+            """.trimIndent()
+        )
+
+        val scriptWithDepFS = FileSpec.newBuilder().apply {
+            projectBuilder.repoRemote = "https://github.com/a/b.git"
+            projectBuilder.revision = "master"
+            projectBuilder.patchBuilder.patch = ByteString.copyFrom(byteArrayOf())
+            path = "scriptWithDep.groovy"
+        }.build()
+
+        // We create another script that tries to access that same dependency.
+        val scriptWithoutDepFile = createTempFile(suffix = ".groovy", directory = tempDir)
+        scriptWithoutDepFile.writeText(
+            """
+            import org.apache.commons.cli.Options;
+            return new Options()
+            """.trimIndent()
+        )
+
+        val scriptWithoutDepFS = FileSpec.newBuilder().apply {
+            projectBuilder.repoRemote = "https://github.com/a/b.git"
+            projectBuilder.revision = "master"
+            projectBuilder.patchBuilder.patch = ByteString.copyFrom(byteArrayOf())
+            path = "scriptWithoutDep.groovy"
+        }.build()
+
+        val loader = DefaultScriptLoader(
+            mockk(relaxUnitFun = true) {
+                every { resolve(scriptWithDepFS) } returns scriptWithDepFile
+                every { resolve(scriptWithoutDepFS) } returns scriptWithoutDepFile
+            }
+        )
+
+        val scriptWithDep = loader.resolveAndLoad(scriptWithDepFS, listOf(), mapOf())
+        val scriptWithoutDep = loader.resolveAndLoad(scriptWithoutDepFS, listOf(), mapOf())
+
+        scriptWithDep.start(listOf(tempDir), null)
+        scriptWithoutDep.start(listOf(tempDir), null)
+
+        // The script that declared the dependency must have access to it.
+        scriptWithDep.join().shouldBeRight {
+            it.shouldNotBeNull()
+            it::class.java.name.shouldBe("org.apache.commons.cli.Options")
+        }
+
+        // The script that did not declare the dependency must not have access to it.
+        scriptWithoutDep.join().shouldBeLeft {
+            it.message.shouldContain("unable to resolve class org.apache.commons.cli.Options")
+        }
+    }
+
+    @Test
+    fun `requirement 2`(@TempDir tempDir: File) {
+        // We create one script that grabs a newer version of a dependency
+        val scriptWithNewerDepFile = createTempFile(suffix = ".groovy", directory = tempDir)
+        scriptWithNewerDepFile.writeText(
+            """
+            @Grapes(@Grab(group = 'commons-cli', module = 'commons-cli', version = '1.4'))
+            import org.apache.commons.cli.Option;
+            import org.apache.commons.cli.Option.Builder;
+            return Option.Builder
+            """.trimIndent()
+        )
+
+        val scriptWithNewerDepFS = FileSpec.newBuilder().apply {
+            projectBuilder.repoRemote = "https://github.com/a/b.git"
+            projectBuilder.revision = "master"
+            projectBuilder.patchBuilder.patch = ByteString.copyFrom(byteArrayOf())
+            path = "scriptWithNewerDep.groovy"
+        }.build()
+
+        // We create another script that grabs an older version of the same dependency and tries to import something
+        // from the newer version of that dependency
+        val scriptWithOlderDepFile = createTempFile(suffix = ".groovy", directory = tempDir)
+        scriptWithOlderDepFile.writeText(
+            """
+            @Grapes(@Grab(group = 'commons-cli', module = 'commons-cli', version = '1.1'))
+            import org.apache.commons.cli.Option;
+            import org.apache.commons.cli.Option.Builder;
+            return Option.Builder
+            """.trimIndent()
+        )
+
+        val scriptWithOlderDepFS = FileSpec.newBuilder().apply {
+            projectBuilder.repoRemote = "https://github.com/a/b.git"
+            projectBuilder.revision = "master"
+            projectBuilder.patchBuilder.patch = ByteString.copyFrom(byteArrayOf())
+            path = "scriptWithOlderDep.groovy"
+        }.build()
+
+        val loader = DefaultScriptLoader(
+            mockk(relaxUnitFun = true) {
+                every { resolve(scriptWithNewerDepFS) } returns scriptWithNewerDepFile
+                every { resolve(scriptWithOlderDepFS) } returns scriptWithOlderDepFile
+            }
+        )
+
+        val scriptWithNewerDep = loader.resolveAndLoad(scriptWithNewerDepFS, listOf(), mapOf())
+        val scriptWithOlderDep = loader.resolveAndLoad(scriptWithOlderDepFS, listOf(), mapOf())
+
+        scriptWithNewerDep.start(listOf(tempDir), null)
+        scriptWithOlderDep.start(listOf(tempDir), null)
+
+        // The script that declared the newer dependency must succeed
+        scriptWithNewerDep.join().shouldBeRight { it.shouldNotBeNull() }
+
+        // The script that declared the older dependency must fail
+        scriptWithOlderDep.join().shouldBeLeft {
+            it.message.shouldContain("unable to resolve class org.apache.commons.cli.Option.Builder")
+        }
+    }
+}


### PR DESCRIPTION
### Description of the Change

This PR adds an integration test that asserts script classpath isolation works as required.

### Motivation

This is required so that scripts do not break each other in unexpected ways at runtime.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?
-->

### Applicable Issues

<!-- Enter any applicable Issues here. E.g., "Closes #49." -->
