### PR TITLE
Implement dependency resolution for FileSpecs with patches

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           submodules: recursive
 
+      - run: git config --global user.email "example@example.com"
+      - run: git config --global user.name "Example User"
+
       - uses: gradle/wrapper-validation-action@v1
 
       - name: Set up JDK 11

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -20,7 +20,7 @@
  * blocks.
  */
 object Versions {
-    const val bowlerKernel = "0.3.35"
+    const val bowlerKernel = "0.3.36"
 
     const val spotlessPlugin = "5.6.1"
     const val testLoggerPlugin = "2.1.0"

--- a/gitfs/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/gitfs/DefaultDependencyResolver.kt
+++ b/gitfs/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/gitfs/DefaultDependencyResolver.kt
@@ -37,6 +37,7 @@ class DefaultDependencyResolver(
 
             val patch = fileSpec.project.patch.patch
             if (!patch.isEmpty) {
+                // TODO: Apply the patch using jgit
                 val proc = ProcessBuilder("git", "apply", "-").directory(repoDir).start()
                 proc.outputStream.write(patch.toByteArray())
                 proc.outputStream.close()

--- a/gitfs/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/gitfs/DefaultDependencyResolver.kt
+++ b/gitfs/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/gitfs/DefaultDependencyResolver.kt
@@ -41,7 +41,10 @@ class DefaultDependencyResolver(
                 val proc = ProcessBuilder("git", "apply", "-").directory(repoDir).start()
                 proc.outputStream.write(patch.toByteArray())
                 proc.outputStream.close()
-                proc.waitFor()
+                val exitCode = proc.waitFor()
+                check(exitCode == 0) {
+                    "Failed to apply the patch (exit code $exitCode) when resolving $fileSpec"
+                }
             }
 
             val file = gitFS.getFilesInRepo(repoDir).flatMap { files ->

--- a/gitfs/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/gitfs/DependencyResolver.kt
+++ b/gitfs/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/gitfs/DependencyResolver.kt
@@ -22,11 +22,16 @@ import java.io.File
 
 /**
  * Resolves the dependencies needed by scripts.
+ *
+ * Important note: the kernel's dependency cache is just that (a cache). The kernel is free to evict cache entries at
+ * any time that would not cause a running program to break. Don't store important changes in the cache.
  */
 interface DependencyResolver {
 
     /**
-     * Resolve a local [File] from a [FileSpec]. Dependency resolution works as follows:
+     * Resolve a local [File] from a [FileSpec].
+     *
+     * Dependency resolution works as follows:
      * 1. Scripts may import scripts from the same project. These dependencies are resolved to the relevant files
      * in that project.
      *
@@ -37,6 +42,9 @@ interface DependencyResolver {
      *
      *     b) If the script being imported is dev'd, that script is resolved to the local (local to the client) version
      *     of that script.
+     *
+     * Patches work as follows. The local copy of the project will be made consistent with the patch. Any previously
+     * applied patch is discarded and overwritten by the new patch.
      */
     fun resolve(fileSpec: FileSpec): File
 

--- a/gitfs/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/gitfs/GitFS.kt
+++ b/gitfs/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/gitfs/GitFS.kt
@@ -21,11 +21,15 @@ import java.io.File
 
 /**
  * An interface to a Git-based file system, typically hosted remotely.
+ *
+ * Important note: the kernel's dependency cache is just that (a cache). The kernel is free to evict cache entries at
+ * any time that would not cause a running program to break. Don't store important changes in the cache.
  */
 interface GitFS {
 
     /**
-     * Clones a repository to the local cache.
+     * Clones a repository to the local cache. The cached copy of the repository will be consistent with the remote
+     * after this method returns. Namely, any local changes will be reset.
      *
      * @param gitUrl The `.git` URL to clone from, i.e.
      * `https://github.com/CommonWealthRobotics/BowlerBuilder.git` or

--- a/gitfs/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/gitfs/GitHubFS.kt
+++ b/gitfs/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/gitfs/GitHubFS.kt
@@ -26,6 +26,7 @@ import com.commonwealthrobotics.bowlerkernel.util.getFullPathToGitHubCacheDirect
 import mu.KotlinLogging
 import org.apache.commons.io.FileUtils
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.ResetCommand
 import org.eclipse.jgit.errors.RepositoryNotFoundException
 import org.eclipse.jgit.errors.TransportException
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
@@ -60,7 +61,10 @@ class GitHubFS(
             logger.info { "Pulling repository in directory $directory" }
             @Suppress("BlockingMethodInNonBlockingContext")
             fsLock.withLock {
-                Git.open(directory).use { it.pull().call() }
+                Git.open(directory).use {
+                    it.reset().setMode(ResetCommand.ResetType.HARD).setRef("HEAD").call()
+                    it.pull().call()
+                }
             }
         }.handleErrorWith {
             if (it is RepositoryNotFoundException) {

--- a/gitfs/src/test/kotlin/com/commonwealthrobotics/bowlerkernel/gitfs/DefaultDependencyResolverTest.kt
+++ b/gitfs/src/test/kotlin/com/commonwealthrobotics/bowlerkernel/gitfs/DefaultDependencyResolverTest.kt
@@ -69,17 +69,19 @@ internal class DefaultDependencyResolverTest {
         fileToResolve.writeText("1")
 
         // Init a git repo, add all files, and commit
-        ProcessBuilder("git", "init", ".").directory(tempDir).start().waitFor()
-        ProcessBuilder("git", "add", ".").directory(tempDir).start().waitFor()
-        ProcessBuilder("git", "commit", "-m", "a").directory(tempDir).start().waitFor()
+        ProcessBuilder("git", "init", ".").directory(tempDir).start().waitFor().shouldBeZero()
+        ProcessBuilder("git", "add", ".").directory(tempDir).start().waitFor().shouldBeZero()
+        ProcessBuilder("git", "commit", "-m", "a").directory(tempDir).start().waitFor().shouldBeZero()
 
         // Write 2 into that file and generate that diff
         fileToResolve.writeText("2")
 
         val diff = ProcessBuilder("git", "diff", "HEAD").directory(tempDir).start().let {
-            it.waitFor()
+            it.waitFor().shouldBeZero()
             it.inputStream.readAllBytes()
         }
+        diff.isNotEmpty().shouldBeTrue() // Sanity check the diff is not empty
+
         // Reset the file back to its old contents so that we can check the diff is applied
         fileToResolve.writeText("1")
 
@@ -109,9 +111,9 @@ internal class DefaultDependencyResolverTest {
     @Test
     fun `resolve a file added in a patch`(@TempDir tempDir: File) {
         // Init a git repo, add all files, and commit
-        ProcessBuilder("git", "init", ".").directory(tempDir).start().waitFor()
-        ProcessBuilder("git", "add", ".").directory(tempDir).start().waitFor()
-        ProcessBuilder("git", "commit", "-m", "a", "--allow-empty").directory(tempDir).start().waitFor()
+        ProcessBuilder("git", "init", ".").directory(tempDir).start().waitFor().shouldBeZero()
+        ProcessBuilder("git", "add", ".").directory(tempDir).start().waitFor().shouldBeZero()
+        ProcessBuilder("git", "commit", "-m", "a", "--allow-empty").directory(tempDir).start().waitFor().shouldBeZero()
 
         // Create a new file
         val aNewFile = createTempFile(suffix = ".groovy", directory = tempDir)

--- a/gitfs/src/test/kotlin/com/commonwealthrobotics/bowlerkernel/gitfs/GitHubFSIntegTest.kt
+++ b/gitfs/src/test/kotlin/com/commonwealthrobotics/bowlerkernel/gitfs/GitHubFSIntegTest.kt
@@ -16,6 +16,7 @@
  */
 package com.commonwealthrobotics.bowlerkernel.gitfs
 
+import arrow.core.Either
 import com.commonwealthrobotics.bowlerkernel.authservice.AnonymousCredentialsProvider
 import io.kotest.assertions.arrow.either.shouldBeLeft
 import io.kotest.assertions.arrow.either.shouldBeRight
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 import kotlin.random.Random
@@ -66,19 +68,8 @@ class GitHubFSIntegTest {
         val fs = GitHubFS(AnonymousCredentialsProvider, tmpCachePath)
         val repoPath = fs.gitHubCacheDirectory.resolve(orgName).resolve(repoName)
 
-        val files = fs.cloneRepo(testRepoUrlHTTPS)
-            .flatMap { fs.getFilesInRepo(it) }
-            .map { files -> files.map { it.toString() }.toSet() }
-            .attempt()
-            .unsafeRunSync()
-
-        files.shouldBeRight {
-            it.shouldContainAll(
-                Paths.get(repoPath.toString(), "fileA.txt").toString(),
-                Paths.get(repoPath.toString(), "dirA").toString(),
-                Paths.get(repoPath.toString(), "dirA", "fileB.txt").toString()
-            )
-        }
+        val files = cloneAndGetFileSet(fs, testRepoUrlHTTPS)
+        assertTestRepoContents(files, repoPath)
     }
 
     @Test
@@ -93,19 +84,33 @@ class GitHubFSIntegTest {
         repoPath.toFile().apply { mkdirs() }
         Paths.get(repoPath.toString(), ".git").toFile().apply { mkdirs() }
 
-        val files = fs.cloneRepo(testRepoUrlHTTPS)
-            .flatMap { fs.getFilesInRepo(it) }
-            .map { files -> files.map { it.toString() }.toSet() }
-            .attempt()
-            .unsafeRunSync()
+        val files = cloneAndGetFileSet(fs, testRepoUrlHTTPS)
+        assertTestRepoContents(files, repoPath)
+    }
 
-        files.shouldBeRight {
-            it.shouldContainAll(
-                Paths.get(repoPath.toString(), "fileA.txt").toString(),
-                Paths.get(repoPath.toString(), "dirA").toString(),
-                Paths.get(repoPath.toString(), "dirA", "fileB.txt").toString()
-            )
-        }
+    @Test
+    fun `test cloning with some local changes`() {
+        // Don't use a TempDir because jgit leaves something open so Windows builds fail
+        val tmpCachePath = getRandomTempFile()
+
+        val fs = GitHubFS(AnonymousCredentialsProvider, tmpCachePath)
+        val repoPath = fs.gitHubCacheDirectory.resolve(orgName).resolve(repoName)
+
+        // Clone the test repo and make sure it worked -- this is our baseline
+        var files = cloneAndGetFileSet(fs, testRepoUrlHTTPS)
+        assertTestRepoContents(files, repoPath)
+
+        // Reset the test repo back one commit so that there is something to pull
+        ProcessBuilder("git", "reset", "--hard", "HEAD^").directory(repoPath.toFile()).start().waitFor()
+
+        // Make some changes that will need to be reset
+        fs.getFilesInRepo(repoPath.toFile()).unsafeRunSync().forEach { it.deleteRecursively() }
+
+        // Try to clone again. The repo should be reset and then pulled. Because we deleted all the files in the
+        // previous commit, git may be able to fast-forward this pull; however, those files will still be deleted. A
+        // correct GitFS implementation will reset the repo.
+        files = cloneAndGetFileSet(fs, testRepoUrlHTTPS)
+        assertTestRepoContents(files, repoPath)
     }
 
     @Test
@@ -125,6 +130,24 @@ class GitHubFSIntegTest {
 
         fileInRepo.shouldNotExist()
         repo.shouldNotExist()
+    }
+
+    private fun cloneAndGetFileSet(fs: GitHubFS, repoURL: String): Either<Throwable, Set<String>> {
+        return fs.cloneRepo(repoURL)
+            .flatMap { fs.getFilesInRepo(it) }
+            .map { files -> files.map { it.toString() }.toSet() }
+            .attempt()
+            .unsafeRunSync()
+    }
+
+    private fun assertTestRepoContents(files: Either<Throwable, Set<String>>, repoPath: Path) {
+        files.shouldBeRight {
+            it.shouldContainAll(
+                Paths.get(repoPath.toString(), "fileA.txt").toString(),
+                Paths.get(repoPath.toString(), "dirA").toString(),
+                Paths.get(repoPath.toString(), "dirA", "fileB.txt").toString()
+            )
+        }
     }
 
     private fun getRandomTempFile() = Paths.get(

--- a/scripthost/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/scripthost/Session.kt
+++ b/scripthost/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/scripthost/Session.kt
@@ -57,6 +57,12 @@ import kotlin.time.ExperimentalTime
 /**
  * Implements the bidirectional session RPC.
  *
+ * Notes to the client:
+ * - Multiple concurrent requests are supported, with some limitations:
+ *      - The Git cache is shared between all requests. This means that you should take care not to send requests that
+ *      cause a later request to overwrite a cache entry that an earlier request is using. For example, resolving two
+ *      FileSpecs that point to the same file.
+ *
  * @param coroutineScope The scope used to process messages from the client flow. Cannot be GlobalScope.
  * @param client The client flow.
  */


### PR DESCRIPTION
### Description of the Change

This PR implements dependency resolution for FileSpecs that have non-empty patches.

This PR also changes the behavior of the gitfs cache, making it more "temporary" (because now it has no problem hard resetting its contents). This is okay now because the gitfs cache no longer stores the user's WIP code, like it did with the old stack.

### Motivation

I am working on the IntelliJ plugin and need this to run scripts.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?
-->

### Applicable Issues

<!-- Enter any applicable Issues here. E.g., "Closes #49." -->
