### PR TITLE
Add kernel server port request to the name server

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
     implementation(group = "org.jline", name = "jline-reader", version = Versions.jline)
     implementation(group = "org.jline", name = "jline-style", version = Versions.jline)
     implementation(group = "org.jline", name = "jline-console", version = Versions.jline)
+
+    testImplementation(project(":testUtil"))
 }
 
 application {

--- a/cli/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/cli/Command.kt
+++ b/cli/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/cli/Command.kt
@@ -133,11 +133,10 @@ internal class Command private constructor(
         if (options.isEmpty()) {
             help
         } else {
-            val optionString = options.joinToString("\n") { it.helpMessage }
+            val optionString = options.joinToString("\n") { it.helpMessage }.prependIndent("    ")
             """
             |$help
-            |
-            |Options:
+            |  Options:
             |$optionString
             """.trimMargin()
         }

--- a/cli/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/cli/Command.kt
+++ b/cli/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/cli/Command.kt
@@ -17,6 +17,7 @@
 package com.commonwealthrobotics.bowlerkernel.cli
 
 import arrow.core.Tuple2
+import arrow.fx.IO
 import org.jline.builtins.Completers
 
 internal class Command private constructor(
@@ -70,12 +71,25 @@ internal class Command private constructor(
         options = options,
     )
 
+    /**
+     * @param args The arguments to this command (not including this command itself).
+     */
     operator fun invoke(args: List<String>): String {
         return if (type == Type.Terminal) {
             val matchedArgs = ArrayList(args)
-            val matchedOptions = options.map { Tuple2(it, it.matchAndRemove(matchedArgs)) }
+            val matchedOptions = options.map {
+                Tuple2(it, IO { it.matchAndRemove(matchedArgs) }.attempt().unsafeRunSync())
+            }
 
-            val requiredButNotMatchedOptions = matchedOptions.filter { it.a.required && it.b == null }
+            val matchedButNotParsedOptions = matchedOptions.filter { it.b.isLeft() }
+            if (matchedButNotParsedOptions.isNotEmpty()) {
+                // These matched but resulted in parse errors
+                return invalidOptions(matchedButNotParsedOptions)
+            }
+
+            val matchedAndParsedOptions = matchedOptions.map { it.map { it.fold({ throw it }, { it }) } }
+
+            val requiredButNotMatchedOptions = matchedAndParsedOptions.filter { it.a.required && it.b == null }
             if (requiredButNotMatchedOptions.isNotEmpty()) {
                 // Not all required options matched
                 return missingOptions(requiredButNotMatchedOptions.map { it.a })
@@ -86,14 +100,14 @@ internal class Command private constructor(
                 return unknownOptions(matchedArgs)
             }
 
-            val invalidMatches = matchedOptions.filter { it.b != null }.filter { !it.a.validator(it.b!!) }
+            val invalidMatches = matchedAndParsedOptions.filter { it.b != null }.filter { !it.a.validator(it.b!!) }
             if (invalidMatches.isNotEmpty()) {
                 // Some options have invalid values
                 return invalidOptions(invalidMatches)
             }
 
             // All required options matched
-            lambda2(matchedOptions).prependIndent("  ")
+            lambda2(matchedAndParsedOptions).prependIndent("  ")
         } else {
             lambda1(args).prependIndent("  ")
         }

--- a/cli/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/cli/Command.kt
+++ b/cli/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/cli/Command.kt
@@ -72,7 +72,10 @@ internal class Command private constructor(
     )
 
     /**
+     * Runs this command.
+     *
      * @param args The arguments to this command (not including this command itself).
+     * @return The output of the command, to be echoed to the terminal.
      */
     operator fun invoke(args: List<String>): String {
         return if (type == Type.Terminal) {

--- a/cli/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/cli/Main.kt
+++ b/cli/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/cli/Main.kt
@@ -172,9 +172,9 @@ object Main {
                         grpcPort.attempt().unsafeRunSync().fold(
                             {
                                 """
-                                    |Encountered exception while requesting the kernel server's port number:
-                                    |${it.localizedMessage}
-                                    """.trimMargin()
+                                |Encountered exception while requesting the kernel server's port number:
+                                |${it.localizedMessage}
+                                """.trimMargin()
                             },
                             { "Kernel server at $address is running on port $it" }
                         )

--- a/cli/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/cli/Main.kt
+++ b/cli/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/cli/Main.kt
@@ -262,11 +262,11 @@ object Main {
  * Gets the value of a required option.
  */
 @Suppress("UNCHECKED_CAST")
-private fun <T> List<Tuple2<Option, *>>.option(long: String): T = first { it.a.long == long }.b as T
+internal fun <T> List<Tuple2<Option, *>>.option(long: String): T = first { it.a.long == long }.b as T
 
 /**
  * Gets the value of a non-required option or a default value if the option was not set.
  */
 @Suppress("UNCHECKED_CAST")
-private fun <T> List<Tuple2<Option, *>>.option(long: String, default: T): T =
+internal fun <T> List<Tuple2<Option, *>>.option(long: String, default: T): T =
     firstOrNull { it.a.long == long }?.b as T? ?: default

--- a/cli/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/cli/Option.kt
+++ b/cli/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/cli/Option.kt
@@ -49,7 +49,7 @@ data class Option(
             null
         } ?: return null
 
-        val value = parse(argValue)
+        val value = parse(clazz, argValue)
         if (value != null) {
             args.removeAt(argIndex) // Remove the option
             args.removeAt(argIndex) // Remove its value
@@ -57,26 +57,28 @@ data class Option(
         return value
     }
 
-    @OptIn(ExperimentalUnsignedTypes::class)
-    private fun parse(value: String): Any? {
-        return when (clazz) {
-            Byte::class -> value.toByte()
-            Short::class -> value.toShort()
-            Int::class -> value.toInt()
-            Long::class -> value.toLong()
-            Float::class -> value.toFloat()
-            Double::class -> value.toDouble()
+    companion object {
+        @OptIn(ExperimentalUnsignedTypes::class)
+        internal fun parse(clazz: KClass<*>, value: String): Any? {
+            return when (clazz) {
+                Byte::class -> value.toByte()
+                Short::class -> value.toShort()
+                Int::class -> value.toInt()
+                Long::class -> value.toLong()
+                Float::class -> value.toFloat()
+                Double::class -> value.toDouble()
 
-            String::class -> value
+                String::class -> value
 
-            InetAddress::class ->
-                try {
-                    InetAddress.getByAddress(value.split('.').map { it.toInt().toByte() }.toByteArray())
-                } catch (ex: UnknownHostException) {
-                    null
-                }
+                InetAddress::class ->
+                    try {
+                        InetAddress.getByAddress(value.split('.').map { it.toInt().toByte() }.toByteArray())
+                    } catch (ex: UnknownHostException) {
+                        null
+                    }
 
-            else -> null
+                else -> null
+            }
         }
     }
 }
@@ -92,9 +94,9 @@ data class Option(
  */
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : Any> option(
-    short: String = "",
-    long: String = "",
-    help: String = "",
+    short: String,
+    long: String,
+    help: String,
     required: Boolean = false,
     noinline validator: (T) -> Boolean = { true }
 ) = Option(T::class, short, long, help, required, validator as (Any) -> Boolean)

--- a/cli/src/test/kotlin/com/commonwealthrobotics/bowlerkernel/cli/CommandTest.kt
+++ b/cli/src/test/kotlin/com/commonwealthrobotics/bowlerkernel/cli/CommandTest.kt
@@ -1,0 +1,245 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.commonwealthrobotics.bowlerkernel.cli
+
+import io.kotest.matchers.longs.shouldBeZero
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+
+internal class CommandTest {
+
+    @Nested
+    inner class TerminalCommands {
+        @Test
+        fun `invoke a terminal command with no options`() {
+            val latch = CountDownLatch(1)
+            val expectedPrintout = "output"
+            val cmd = Command(name = "foo", help = "") { latch.countDown(); expectedPrintout }
+            val args = mutableListOf<String>()
+            cmd(args).shouldContain(expectedPrintout)
+            latch.count.shouldBeZero()
+        }
+
+        @Test
+        fun `invoke a terminal command with one non-required option`() {
+            val latch = CountDownLatch(1)
+            val cmd = Command(
+                name = "foo",
+                help = "bar",
+                options = listOf(
+                    option<Int>(
+                        short = "a",
+                        long = "aa",
+                        help = "",
+                        required = false
+                    )
+                )
+            ) {
+                it.option<Int>("aa").shouldBe(1)
+                latch.countDown()
+                ""
+            }
+            val args = mutableListOf("-a", "1")
+            cmd(args)
+            latch.count.shouldBeZero()
+        }
+
+        @Test
+        fun `invoke a terminal command with one required option`() {
+            val latch = CountDownLatch(1)
+            val cmd = Command(
+                name = "foo",
+                help = "bar",
+                options = listOf(
+                    option<Int>(
+                        short = "a",
+                        long = "aa",
+                        help = "",
+                        required = true
+                    )
+                )
+            ) {
+                it.option<Int>("aa").shouldBe(1)
+                latch.countDown()
+                ""
+            }
+            val args = mutableListOf("-a", "1")
+            cmd(args)
+            latch.count.shouldBeZero()
+        }
+
+        @Test
+        fun `invoke a terminal command with one missing required option`() {
+            val latch = CountDownLatch(1)
+            val cmd = Command(
+                name = "foo",
+                help = "bar",
+                options = listOf(
+                    option<Int>(
+                        short = "a",
+                        long = "aa",
+                        help = "",
+                        required = true
+                    )
+                )
+            ) {
+                latch.countDown()
+                ""
+            }
+            val args = mutableListOf<String>()
+            cmd(args).apply {
+                shouldContain("Missing option")
+                shouldContain("aa")
+            }
+            latch.count.shouldBe(1)
+        }
+
+        @Test
+        fun `invoke a terminal command with one missing non-required option`() {
+            val latch = CountDownLatch(1)
+            val cmd = Command(
+                name = "foo",
+                help = "bar",
+                options = listOf(
+                    option<Int>(
+                        short = "a",
+                        long = "aa",
+                        help = "",
+                        required = false
+                    )
+                )
+            ) {
+                it.option("aa", 2).shouldBe(2)
+                latch.countDown()
+                ""
+            }
+            val args = mutableListOf<String>()
+            cmd(args)
+            latch.count.shouldBe(0)
+        }
+
+        @Test
+        fun `invoke a terminal command with one option with a missing value`() {
+            val latch = CountDownLatch(1)
+            val cmd = Command(
+                name = "foo",
+                help = "bar",
+                options = listOf(
+                    option<Int>(
+                        short = "a",
+                        long = "aa",
+                        help = "",
+                        required = false
+                    )
+                )
+            ) {
+                latch.countDown()
+                ""
+            }
+            val args = mutableListOf("-a") // Don't pass a value
+            cmd(args)
+            latch.count.shouldBe(1)
+        }
+
+        @Test
+        fun `invoke a terminal command with one option with an invalid value`() {
+            val latch = CountDownLatch(1)
+            val cmd = Command(
+                name = "foo",
+                help = "bar",
+                options = listOf(
+                    option<Int>(
+                        short = "a",
+                        long = "aa",
+                        help = "",
+                        required = false,
+                        validator = { false }
+                    )
+                )
+            ) {
+                latch.countDown()
+                ""
+            }
+            val args = mutableListOf("-a", "1")
+            cmd(args).apply {
+                shouldContain("Invalid option")
+                shouldContain("aa")
+            }
+            latch.count.shouldBe(1)
+        }
+
+        @Test
+        fun `invoke a terminal command with one option that fails to parse`() {
+            val latch = CountDownLatch(1)
+            val cmd = Command(
+                name = "foo",
+                help = "bar",
+                options = listOf(
+                    option<Int>(
+                        short = "a",
+                        long = "aa",
+                        help = "",
+                        required = false,
+                        validator = { false }
+                    )
+                )
+            ) {
+                latch.countDown()
+                ""
+            }
+            val args = mutableListOf("-a", "q")
+            cmd(args).apply {
+                shouldContain("Invalid option")
+                shouldContain("aa")
+            }
+            latch.count.shouldBe(1)
+        }
+
+        @Test
+        fun `passing an unknown option is an error`() {
+            val cmd = Command(name = "foo", help = "") { "" }
+            val args = mutableListOf("option1")
+            cmd(args).apply {
+                shouldContain("Unknown option")
+                args.forEach { shouldContain(it) }
+            }
+        }
+    }
+
+    @Nested
+    inner class NonTerminalCommands {
+        @Test
+        fun `run a non-terminal command`() {
+            val latch = CountDownLatch(1)
+            val expectedPrintout = "output"
+            val cmd = Command(
+                name = "foo",
+                children = listOf(
+                    Command(name = "inner1", help = "") { "" },
+                    Command(name = "inner2", help = "") { latch.countDown(); expectedPrintout },
+                    Command(name = "inner3", help = "") { "" },
+                )
+            )
+            val args = mutableListOf("inner2")
+            cmd(args).shouldContain(expectedPrintout)
+            latch.count.shouldBeZero()
+        }
+    }
+}

--- a/cli/src/test/kotlin/com/commonwealthrobotics/bowlerkernel/cli/OptionTest.kt
+++ b/cli/src/test/kotlin/com/commonwealthrobotics/bowlerkernel/cli/OptionTest.kt
@@ -1,0 +1,81 @@
+/*
+ * This file is part of bowler-kernel.
+ *
+ * bowler-kernel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * bowler-kernel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with bowler-kernel.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.commonwealthrobotics.bowlerkernel.cli
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.net.InetAddress
+
+internal class OptionTest {
+
+    @Test
+    fun `match no arg`() {
+        val option = option<Int>(short = "a", long = "aa", help = "")
+        option.matchAndRemove(mutableListOf()).shouldBeNull()
+    }
+
+    @Test
+    fun `match the short switch`() {
+        val option = option<Int>(short = "a", long = "aa", help = "")
+        val args = mutableListOf("-a", "1")
+        option.matchAndRemove(args).shouldBe(1)
+        args.shouldBeEmpty()
+    }
+
+    @Test
+    fun `match the long switch`() {
+        val option = option<Int>(short = "a", long = "aa", help = "")
+        val args = mutableListOf("--aa", "1")
+        option.matchAndRemove(args).shouldBe(1)
+        args.shouldBeEmpty()
+    }
+
+    @Test
+    fun `don't match a different switch`() {
+        val option = option<Int>(short = "a", long = "aa", help = "")
+        val args = mutableListOf("--ab", "1")
+        option.matchAndRemove(args).shouldBeNull()
+        args.shouldContainExactly("--ab", "1")
+    }
+
+    @Test
+    fun `match a short switch but fail parsing`() {
+        val option = option<Int>(short = "a", long = "aa", help = "")
+        val args = mutableListOf("-a", "q")
+        shouldThrow<NumberFormatException> {
+            option.matchAndRemove(args)
+        }
+    }
+
+    @Test
+    fun `parse ipv4`() {
+        Option.parse(InetAddress::class, "192.168.1.177").shouldBe(
+            InetAddress.getByAddress(
+                byteArrayOf(
+                    192.toByte(),
+                    168.toByte(),
+                    1.toByte(),
+                    177.toByte()
+                )
+            )
+        )
+    }
+}

--- a/kernel-discovery/build.gradle.kts
+++ b/kernel-discovery/build.gradle.kts
@@ -2,6 +2,7 @@ description = "Implements the name server and client used for kernel discovery."
 
 dependencies {
     api(group = "io.arrow-kt", name = "arrow-core-data", version = Versions.arrow)
+    api(group = "io.arrow-kt", name = "arrow-fx", version = Versions.arrow)
     implementation(project(":util"))
 
     runtimeOnly(project(":logging"))

--- a/kernel-discovery/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/kerneldiscovery/NameClient.kt
+++ b/kernel-discovery/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/kerneldiscovery/NameClient.kt
@@ -85,7 +85,9 @@ object NameClient {
         socket.soTimeout = timeoutMs
 
         logger.debug { "Sending to $address:$port" }
-        socket.send(DatagramPacket(NameServer.getGrpcPortBytes, NameServer.getGrpcPortBytes.size, address, port))
+        socket.send(
+            DatagramPacket(NameServer.getKernelServerPortBytes, NameServer.getKernelServerPortBytes.size, address, port)
+        )
 
         val reply = DatagramPacket(ByteArray(NameServer.maxReplyLength), NameServer.maxReplyLength)
         for (i in 1..attempts) {

--- a/kernel-discovery/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/kerneldiscovery/NameServer.kt
+++ b/kernel-discovery/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/kerneldiscovery/NameServer.kt
@@ -22,6 +22,8 @@ import java.net.InetAddress
 import java.net.MulticastSocket
 import java.net.NetworkInterface
 import java.net.SocketTimeoutException
+import java.nio.ByteBuffer
+import java.util.Arrays
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.concurrent.thread
 import kotlin.random.Random
@@ -36,11 +38,13 @@ import kotlin.streams.asSequence
  * Multicast Range for Organization-Local Scope (239.0.0.0-239.255.255.255) specified in RFC5771.
  * @param desiredPort The port the server should bind to. This should be in the Dynamic Port Number Range
  * (49152-65535) specified in RFC6335.
+ * @param getGrpcPort A lambda used to get the current kernel server's port number, if a kernel server will be used.
  */
 class NameServer(
     private val desiredName: String,
     private val multicastGroup: InetAddress = defaultMulticastGroup,
-    private val desiredPort: Int = defaultPort
+    private val desiredPort: Int = defaultPort,
+    private val getGrpcPort: () -> Int = { 0 },
 ) {
 
     val name: String
@@ -113,26 +117,31 @@ class NameServer(
         isRunning.set(true)
 
         try {
-            val packetBuf = ByteArray(8)
+            // Payload format:
+            //  - One byte header specifying the number of bytes of data
+            //  - n bytes of data a format dependent on the type of the request. Numbers are big endian. Strings are
+            //    UTF-8.
+            //
+            // Request types:
+            //  - getName: data is the name (string)
+            //  - getGrpcPort: data is the port number (int)
+            val packetBuf = ByteArray(maxRequestLength)
             val packet = DatagramPacket(packetBuf, packetBuf.size)
             val nameBytes = name.encodeToByteArray()
-            val payload = ByteArray(nameBytes.size + 1) {
-                if (it == 0) {
-                    nameBytes.size.toByte()
-                } else {
-                    nameBytes[it - 1]
-                }
-            }
+            val payload = ByteArray(maxReplyLength)
 
             while (!Thread.interrupted()) {
                 try {
                     socket.receive(packet)
-                    if (packet.data.contentEquals(getNameBytes)) {
-                        check(payload.size <= maxReplyLength) {
-                            "Payload size invariant broke: payload.size=${payload.size} maxReplyLength=$maxReplyLength"
-                        }
-                        socket.send(DatagramPacket(payload, payload.size, packet.address, packet.port))
+                    logger.debug { "Got: ${packet.data.joinToString()}" }
+
+                    when {
+                        hasGetNameRequest(packet) -> setPayload(payload, nameBytes)
+                        hasGetGrpcPortRequest(packet) -> setPayloadToPortNumber(payload, getGrpcPort())
+                        else -> clearPayload(payload)
                     }
+
+                    socket.send(DatagramPacket(payload, payload.size, packet.address, packet.port))
                 } catch (ex: SocketTimeoutException) {
                     // Ignored
                 }
@@ -150,11 +159,36 @@ class NameServer(
         }
     }
 
+    private fun hasGetNameRequest(packet: DatagramPacket) =
+        Arrays.equals(packet.data, 0, getNameBytes.size, getNameBytes, 0, getNameBytes.size)
+
+    private fun hasGetGrpcPortRequest(packet: DatagramPacket) =
+        Arrays.equals(packet.data, 0, getGrpcPortBytes.size, getGrpcPortBytes, 0, getGrpcPortBytes.size)
+
+    private fun setPayloadToPortNumber(payload: ByteArray, port: Int) {
+        payload[0] = Int.SIZE_BYTES.toByte()
+        ByteBuffer.allocate(Int.SIZE_BYTES).putInt(port).rewind().get(payload, 1, Int.SIZE_BYTES)
+    }
+
+    private fun setPayload(payload: ByteArray, bytes: ByteArray) {
+        payload[0] = bytes.size.toByte()
+        for (i in 1..bytes.size) {
+            payload[i] = bytes[i - 1]
+        }
+    }
+
+    private fun clearPayload(payload: ByteArray) {
+        for (i in payload.indices) {
+            payload[i] = 0
+        }
+    }
+
     companion object {
 
         private val logger = KotlinLogging.logger { }
 
         val getNameBytes = "get-name".encodeToByteArray()
+        val getGrpcPortBytes = "get-grpc-port".encodeToByteArray()
 
         /**
          * The default multicast group the kernel server joins. This is within the IANA Scoped Multicast Range for
@@ -169,6 +203,11 @@ class NameServer(
          * specified in RFC6335.
          */
         const val defaultPort = 62657
+
+        /**
+         * The maximum payload size of a request.
+         */
+        const val maxRequestLength = 100
 
         /**
          * The maximum payload size of a reply.

--- a/kernel-discovery/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/kerneldiscovery/NameServer.kt
+++ b/kernel-discovery/src/main/kotlin/com/commonwealthrobotics/bowlerkernel/kerneldiscovery/NameServer.kt
@@ -137,7 +137,7 @@ class NameServer(
 
                     when {
                         hasGetNameRequest(packet) -> setPayload(payload, nameBytes)
-                        hasGetGrpcPortRequest(packet) -> setPayloadToPortNumber(payload, getGrpcPort())
+                        hasGetKernelServerPortRequest(packet) -> setPayloadToPortNumber(payload, getGrpcPort())
                         else -> clearPayload(payload)
                     }
 
@@ -162,8 +162,15 @@ class NameServer(
     private fun hasGetNameRequest(packet: DatagramPacket) =
         Arrays.equals(packet.data, 0, getNameBytes.size, getNameBytes, 0, getNameBytes.size)
 
-    private fun hasGetGrpcPortRequest(packet: DatagramPacket) =
-        Arrays.equals(packet.data, 0, getGrpcPortBytes.size, getGrpcPortBytes, 0, getGrpcPortBytes.size)
+    private fun hasGetKernelServerPortRequest(packet: DatagramPacket) =
+        Arrays.equals(
+            packet.data,
+            0,
+            getKernelServerPortBytes.size,
+            getKernelServerPortBytes,
+            0,
+            getKernelServerPortBytes.size
+        )
 
     private fun setPayloadToPortNumber(payload: ByteArray, port: Int) {
         payload[0] = Int.SIZE_BYTES.toByte()
@@ -188,7 +195,7 @@ class NameServer(
         private val logger = KotlinLogging.logger { }
 
         val getNameBytes = "get-name".encodeToByteArray()
-        val getGrpcPortBytes = "get-grpc-port".encodeToByteArray()
+        val getKernelServerPortBytes = "get-kernel-server-port".encodeToByteArray()
 
         /**
          * The default multicast group the kernel server joins. This is within the IANA Scoped Multicast Range for

--- a/kernel-discovery/src/test/kotlin/com/commonwealthrobotics/bowlerkernel/kerneldiscovery/DiscoveryRoundTripTest.kt
+++ b/kernel-discovery/src/test/kotlin/com/commonwealthrobotics/bowlerkernel/kerneldiscovery/DiscoveryRoundTripTest.kt
@@ -34,12 +34,17 @@ internal class DiscoveryRoundTripTest {
     @Test
     fun `scan the local host with one server running`() {
         val name = "kernel"
+        val grpcPort = 53929
 
-        val ns = NameServer(name)
+        val ns = NameServer(name, getGrpcPort = { grpcPort })
         ns.ensureStarted()
         ns.name.shouldBe(name)
         while (!ns.isRunning.get()) { Thread.sleep(10) }
-        NameClient.scan().map { it.a }.shouldContainExactly(name)
+
+        val scan = NameClient.scan()
+        scan.map { it.a }.shouldContainExactly(name)
+
+        NameClient.getGrpcPort(scan.first().b).unsafeRunSync().shouldBe(grpcPort)
 
         ns.ensureStopped()
         ns.isRunning.get().shouldBeFalse()


### PR DESCRIPTION
### Description of the Change

This PR adds a new request type to the name server for requesting the kernel server's port number.

### Motivation

This will be used by clients to ask for the kernel server's port number.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Unit tests. Also did an integration test by hand via the REPL.
Demo: https://asciinema.org/a/7pJ1KxaTo54VVNIDcB6ZY7lOQ

### Applicable Issues

<!-- Enter any applicable Issues here. E.g., "Closes #49." -->
